### PR TITLE
Added DamageDelay setting for WALKDELAY_SYNC

### DIFF
--- a/db/pre-re/mob_db.conf
+++ b/db/pre-re/mob_db.conf
@@ -150,6 +150,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1564
 	AttackMotion: 864
+	DamageDelay: 360
 	DamageMotion: 576
 	Drops: {
 		Boody_Red: 70
@@ -196,6 +197,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Jellopy: 7000
@@ -275,6 +277,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1292
 	AttackMotion: 792
+	DamageDelay: 742
 	DamageMotion: 216
 	Drops: {
 		Wind_Of_Verdure: 80
@@ -323,6 +326,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1276
 	AttackMotion: 576
+	DamageDelay: 540
 	DamageMotion: 384
 	Drops: {
 		Tooth_Of_Bat: 5500
@@ -407,6 +411,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1672
 	AttackMotion: 672
+	DamageDelay: 180
 	DamageMotion: 480
 	Drops: {
 		Fluff: 6500
@@ -451,6 +456,7 @@ mob_db: (
 	MoveSpeed: 1000
 	AttackDelay: 1001
 	AttackMotion: 1
+	DamageDelay: 900
 	DamageMotion: 1
 	Drops: {
 		Phracon: 80
@@ -498,6 +504,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1148
 	AttackMotion: 648
+	DamageDelay: 607
 	DamageMotion: 480
 	Drops: {
 		Talon: 9000
@@ -543,6 +550,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1672
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 432
 	Drops: {
 		Tree_Root: 9000
@@ -589,6 +597,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1076
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Iron: 50
@@ -634,6 +643,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 2016
 	AttackMotion: 816
+	DamageDelay: 315
 	DamageMotion: 288
 	Drops: {
 		Sticky_Webfoot: 9000
@@ -679,6 +689,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1054
 	AttackMotion: 504
+	DamageDelay: 202
 	DamageMotion: 432
 	Drops: {
 		Emveretarcon: 20
@@ -724,6 +735,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 630
 	DamageMotion: 288
 	Drops: {
 		Mushroom_Spore: 9000
@@ -773,6 +785,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 2612
 	AttackMotion: 912
+	DamageDelay: 855
 	DamageMotion: 288
 	Drops: {
 		Decayed_Nail: 9000
@@ -818,6 +831,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 2864
 	AttackMotion: 864
+	DamageDelay: 630
 	DamageMotion: 576
 	Drops: {
 		Skel_Bone: 4500
@@ -912,6 +926,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1136
 	AttackMotion: 720
+	DamageDelay: 405
 	DamageMotion: 840
 	Drops: {
 		Powder_Of_Butterfly: 9000
@@ -959,6 +974,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1564
 	AttackMotion: 864
+	DamageDelay: 450
 	DamageMotion: 576
 	Drops: {
 		Bill_Of_Birds: 9000
@@ -1003,6 +1019,7 @@ mob_db: (
 	MoveSpeed: 1000
 	AttackDelay: 1768
 	AttackMotion: 768
+	DamageDelay: 360
 	DamageMotion: 576
 	Drops: {
 		Yellow_Live: 50
@@ -1147,6 +1164,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1864
 	AttackMotion: 864
+	DamageDelay: 810
 	DamageMotion: 288
 	Drops: {
 		Iron: 210
@@ -1193,6 +1211,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1048
 	AttackMotion: 48
+	DamageDelay: 270
 	DamageMotion: 192
 	Drops: {
 		Yellow_Live: 60
@@ -1239,6 +1258,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1576
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 576
 	Drops: {
 		Scale_Of_Snakes: 9000
@@ -1288,6 +1308,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 2468
 	AttackMotion: 768
+	DamageDelay: 450
 	DamageMotion: 288
 	Drops: {
 		Danggie: 9000
@@ -1377,6 +1398,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 2276
 	AttackMotion: 576
+	DamageDelay: 202
 	DamageMotion: 432
 	Drops: {
 		Skel_Bone: 5500
@@ -1427,6 +1449,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1384
 	AttackMotion: 768
+	DamageDelay: 450
 	DamageMotion: 336
 	Drops: {
 		Scales_Shell: 5335
@@ -1473,6 +1496,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1576
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 576
 	Drops: {
 		Emveretarcon: 50
@@ -1519,6 +1543,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1672
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Sticky_Mucus: 5500
@@ -1565,6 +1590,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 2468
 	AttackMotion: 768
+	DamageDelay: 450
 	DamageMotion: 480
 	Drops: {
 		Immortal_Heart: 9000
@@ -1614,6 +1640,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1372
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 432
 	Drops: {
 		Boody_Red: 50
@@ -1659,6 +1686,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 2016
 	AttackMotion: 816
+	DamageDelay: 315
 	DamageMotion: 288
 	Drops: {
 		Emveretarcon: 45
@@ -1708,6 +1736,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 676
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Rough_Wind: 30
@@ -1757,6 +1786,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 2456
 	AttackMotion: 912
+	DamageDelay: 427
 	DamageMotion: 504
 	Drops: {
 		Horrendous_Mouth: 6000
@@ -1806,6 +1836,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1576
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 576
 	Drops: {
 		Shining_Scales: 5335
@@ -1859,6 +1890,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1072
 	AttackMotion: 672
+	DamageDelay: 180
 	DamageMotion: 384
 	MvpExp: 35750
 	MvpDrops: {
@@ -1918,6 +1950,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 768
 	AttackMotion: 768
+	DamageDelay: 540
 	DamageMotion: 576
 	MvpExp: 53625
 	MvpDrops: {
@@ -1970,6 +2003,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1608
 	AttackMotion: 816
+	DamageDelay: 945
 	DamageMotion: 396
 	Drops: {
 		Steel: 150
@@ -2019,6 +2053,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1772
 	AttackMotion: 72
+	DamageDelay: 270
 	DamageMotion: 384
 	Drops: {
 		Rotten_Bandage: 9000
@@ -2068,6 +2103,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1076
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Wind_Of_Verdure: 90
@@ -2154,6 +2190,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 360
 	DamageMotion: 288
 	Drops: {
 		Mistic_Frozen: 13
@@ -2203,6 +2240,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1272
 	AttackMotion: 72
+	DamageDelay: 202
 	DamageMotion: 480
 	Drops: {
 		Mistic_Frozen: 18
@@ -2256,6 +2294,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 480
 	AttackMotion: 480
+	DamageDelay: 180
 	DamageMotion: 288
 	MvpExp: 25740
 	MvpDrops: {
@@ -2302,6 +2341,7 @@ mob_db: (
 	MoveSpeed: 1000
 	AttackDelay: 1001
 	AttackMotion: 1
+	DamageDelay: 810
 	DamageMotion: 1
 	Drops: {
 		Phracon: 250
@@ -2346,6 +2386,7 @@ mob_db: (
 	MoveSpeed: 1000
 	AttackDelay: 701
 	AttackMotion: 1
+	DamageDelay: 450
 	DamageMotion: 1
 	Drops: {
 		Phracon: 300
@@ -2391,6 +2432,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 988
 	AttackMotion: 288
+	DamageDelay: 270
 	DamageMotion: 168
 	Drops: {
 		Feather_Of_Birds: 9000
@@ -2435,6 +2477,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 988
 	AttackMotion: 288
+	DamageDelay: 270
 	DamageMotion: 168
 	Drops: {
 		Feather_Of_Birds: 9000
@@ -2484,6 +2527,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 720
 	DamageMotion: 768
 	Drops: {
 		Worm_Peelings: 2500
@@ -2529,6 +2573,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1864
 	AttackMotion: 864
+	DamageDelay: 810
 	DamageMotion: 540
 	Drops: {
 		Grasshoppers_Leg: 9000
@@ -2579,6 +2624,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 988
 	AttackMotion: 288
+	DamageDelay: 720
 	DamageMotion: 768
 	Drops: {
 		Worm_Peelings: 3500
@@ -2630,6 +2676,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 988
 	AttackMotion: 288
+	DamageDelay: 720
 	DamageMotion: 768
 	Drops: {
 		Emveretarcon: 40
@@ -2675,6 +2722,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1960
 	AttackMotion: 960
+	DamageDelay: 450
 	DamageMotion: 384
 	Drops: {
 		Yellow_Live: 70
@@ -2721,6 +2769,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1576
 	AttackMotion: 576
+	DamageDelay: 540
 	DamageMotion: 420
 	Drops: {
 		Raccoon_Leaf: 5500
@@ -2769,6 +2818,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1054
 	AttackMotion: 54
+	DamageDelay: 472
 	DamageMotion: 384
 	Drops: {
 		Yoyo_Tail: 9000
@@ -2818,6 +2868,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1708
 	AttackMotion: 1008
+	DamageDelay: 472
 	DamageMotion: 540
 	Drops: {
 		Boody_Red: 60
@@ -2871,6 +2922,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1148
 	AttackMotion: 648
+	DamageDelay: 607
 	DamageMotion: 300
 	MvpExp: 19662
 	MvpDrops: {
@@ -2923,6 +2975,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1260
 	AttackMotion: 192
+	DamageDelay: 1181
 	DamageMotion: 192
 	Drops: {
 		Bears_Foot: 9000
@@ -2974,6 +3027,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1816
 	AttackMotion: 816
+	DamageDelay: 765
 	DamageMotion: 432
 	Drops: {
 		Horseshoe: 6000
@@ -3019,6 +3073,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1672
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Candy: 2000
@@ -3063,6 +3118,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1456
 	AttackMotion: 456
+	DamageDelay: 247
 	DamageMotion: 336
 	Drops: {
 		Clover: 6500
@@ -3108,6 +3164,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 2492
 	AttackMotion: 792
+	DamageDelay: 652
 	DamageMotion: 432
 	Drops: {
 		Rotten_Scale: 5500
@@ -3157,6 +3214,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 101
 	DamageMotion: 384
 	Drops: {
 		Fin: 5335
@@ -3203,6 +3261,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1632
 	AttackMotion: 432
+	DamageDelay: 393
 	DamageMotion: 540
 	Drops: {
 		Crystal_Blue: 40
@@ -3249,6 +3308,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1248
 	AttackMotion: 48
+	DamageDelay: 180
 	DamageMotion: 480
 	Drops: {
 		Crystal_Blue: 45
@@ -3294,6 +3354,7 @@ mob_db: (
 	MoveSpeed: 1000
 	AttackDelay: 800
 	AttackMotion: 432
+	DamageDelay: 315
 	DamageMotion: 600
 	Drops: {
 		Emveretarcon: 25
@@ -3342,6 +3403,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1968
 	AttackMotion: 768
+	DamageDelay: 180
 	DamageMotion: 384
 	Drops: {
 		Mistic_Frozen: 10
@@ -3388,6 +3450,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1776
 	AttackMotion: 576
+	DamageDelay: 540
 	DamageMotion: 288
 	Drops: {
 		Crystal_Blue: 30
@@ -3437,6 +3500,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1754
 	AttackMotion: 554
+	DamageDelay: 337
 	DamageMotion: 288
 	Drops: {
 		Skel_Bone: 3000
@@ -3487,6 +3551,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1700
 	AttackMotion: 1000
+	DamageDelay: 405
 	DamageMotion: 500
 	Drops: {
 		Flame_Heart: 30
@@ -3532,6 +3597,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 992
 	AttackMotion: 792
+	DamageDelay: 270
 	DamageMotion: 360
 	Drops: {
 		Crap_Shell: 5500
@@ -3576,6 +3642,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 864
 	AttackMotion: 864
+	DamageDelay: 438
 	DamageMotion: 384
 	Drops: {
 		Clam_Shell: 5500
@@ -3656,6 +3723,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 2228
 	AttackMotion: 528
+	DamageDelay: 315
 	DamageMotion: 576
 	Drops: {
 		Phracon: 90
@@ -3704,6 +3772,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1672
 	AttackMotion: 672
+	DamageDelay: 630
 	DamageMotion: 288
 	Drops: {
 		Poison_Spore: 9000
@@ -3748,6 +3817,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 1
 	AttackMotion: 1
+	DamageDelay: 1080
 	DamageMotion: 1
 	Drops: {
 		Red_Herb: 5500
@@ -3792,6 +3862,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 1
 	AttackMotion: 1
+	DamageDelay: 1080
 	DamageMotion: 1
 	Drops: {
 		Blue_Herb: 5500
@@ -3836,6 +3907,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 1
 	AttackMotion: 1
+	DamageDelay: 1080
 	DamageMotion: 1
 	Drops: {
 		Green_Herb: 7000
@@ -3880,6 +3952,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 1
 	AttackMotion: 1
+	DamageDelay: 1080
 	DamageMotion: 1
 	Drops: {
 		Yellow_Herb: 5500
@@ -3924,6 +3997,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 1
 	AttackMotion: 1
+	DamageDelay: 1080
 	DamageMotion: 1
 	Drops: {
 		White_Herb: 5500
@@ -3968,6 +4042,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 1
 	AttackMotion: 1
+	DamageDelay: 2070
 	DamageMotion: 1
 	Drops: {
 		Blue_Herb: 5500
@@ -4012,6 +4087,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 1
 	AttackMotion: 1
+	DamageDelay: 90
 	DamageMotion: 1
 	Drops: {
 		Alchol: 50
@@ -4056,6 +4132,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 1
 	AttackMotion: 1
+	DamageDelay: 90
 	DamageMotion: 1
 	Drops: {
 		Alchol: 50
@@ -4106,6 +4183,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 768
 	AttackMotion: 768
+	DamageDelay: 720
 	DamageMotion: 480
 	MvpExp: 7150
 	MvpDrops: {
@@ -4164,6 +4242,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1678
 	AttackMotion: 780
+	DamageDelay: 731
 	DamageMotion: 648
 	MvpExp: 29315
 	MvpDrops: {
@@ -4222,6 +4301,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1080
 	AttackMotion: 648
+	DamageDelay: 607
 	DamageMotion: 480
 	Drops: {
 		Oldmans_Romance: 50
@@ -4275,6 +4355,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1236
 	AttackMotion: 336
+	DamageDelay: 157
 	DamageMotion: 432
 	Drops: {
 		Big_Sis_Ribbon: 50
@@ -4328,6 +4409,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1072
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Snowy_Horn: 200
@@ -4381,6 +4463,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1076
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Sweet_Gents: 200
@@ -4434,6 +4517,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1048
 	AttackMotion: 648
+	DamageDelay: 202
 	DamageMotion: 432
 	Drops: {
 		Western_Grace: 200
@@ -4487,6 +4571,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1456
 	AttackMotion: 456
+	DamageDelay: 247
 	DamageMotion: 336
 	Drops: {
 		Fillet: 200
@@ -4534,6 +4619,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 2048
 	AttackMotion: 648
+	DamageDelay: 292
 	DamageMotion: 648
 	Drops: {
 		Crystal_Blue: 50
@@ -4583,6 +4669,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 168
 	DamageMotion: 384
 	Drops: {
 		Worm_Peelings: 9000
@@ -4636,6 +4723,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1072
 	AttackMotion: 672
+	DamageDelay: 292
 	DamageMotion: 672
 	Drops: {
 		Angelic_Chain: 100
@@ -4677,6 +4765,7 @@ mob_db: (
 	MoveSpeed: 1000
 	AttackDelay: 1001
 	AttackMotion: 1
+	DamageDelay: 720
 	DamageMotion: 1
 	Drops: {
 		Phracon: 320
@@ -4727,6 +4816,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1250
 	AttackMotion: 768
+	DamageDelay: 450
 	DamageMotion: 360
 	Drops: {
 		Rotten_Bandage: 3000
@@ -4779,6 +4869,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1792
 	AttackMotion: 792
+	DamageDelay: 540
 	DamageMotion: 336
 	Drops: {
 		Short_Leg: 5335
@@ -4828,6 +4919,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1468
 	AttackMotion: 468
+	DamageDelay: 202
 	DamageMotion: 768
 	Drops: {
 		Spiderweb: 9000
@@ -4880,6 +4972,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 868
 	AttackMotion: 480
+	DamageDelay: 202
 	DamageMotion: 120
 	Drops: {
 		Evil_Horn: 500
@@ -4931,6 +5024,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1504
 	AttackMotion: 840
+	DamageDelay: 270
 	DamageMotion: 900
 	Drops: {
 		Sparkling_Dust: 200
@@ -4977,6 +5071,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1604
 	AttackMotion: 840
+	DamageDelay: 202
 	DamageMotion: 756
 	Drops: {
 		Porcupine_Spike: 9000
@@ -5022,6 +5117,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1864
 	AttackMotion: 864
+	DamageDelay: 472
 	DamageMotion: 1008
 	Drops: {
 		Acorn: 9000
@@ -5071,6 +5167,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 135
 	DamageMotion: 576
 	Drops: {
 		Worm_Peelings: 9000
@@ -5120,6 +5217,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1120
 	AttackMotion: 420
+	DamageDelay: 168
 	DamageMotion: 288
 	Drops: {
 		Katar_: 5
@@ -5168,6 +5266,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1600
 	AttackMotion: 900
+	DamageDelay: 236
 	DamageMotion: 240
 	Drops: {
 		Phracon: 85
@@ -5214,6 +5313,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1680
 	AttackMotion: 480
+	DamageDelay: 270
 	DamageMotion: 384
 	Drops: {
 		Mistic_Frozen: 25
@@ -5266,6 +5366,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 980
 	AttackMotion: 600
+	DamageDelay: 270
 	DamageMotion: 384
 	Drops: {
 		Petite_DiablOfs_Horn: 5335
@@ -5313,6 +5414,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1156
 	AttackMotion: 456
+	DamageDelay: 270
 	DamageMotion: 384
 	Drops: {
 		Dokkaebi_Horn: 9000
@@ -5362,6 +5464,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1276
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 384
 	Drops: {
 		Emveretarcon: 60
@@ -5415,6 +5518,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 620
 	AttackMotion: 420
+	DamageDelay: 101
 	DamageMotion: 360
 	MvpExp: 14300
 	MvpDrops: {
@@ -5466,6 +5570,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1372
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Jellopy: 7500
@@ -5513,6 +5618,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1004
 	AttackMotion: 504
+	DamageDelay: 236
 	DamageMotion: 384
 	Drops: {
 		Moth_Dust: 9000
@@ -5565,6 +5671,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 872
 	AttackMotion: 1344
+	DamageDelay: 382
 	DamageMotion: 432
 	MvpExp: 12512
 	MvpDrops: {
@@ -5617,6 +5724,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1816
 	AttackMotion: 816
+	DamageDelay: 450
 	DamageMotion: 288
 	Drops: {
 		Scell: 1000
@@ -5668,6 +5776,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 2276
 	AttackMotion: 576
+	DamageDelay: 157
 	DamageMotion: 336
 	Drops: {
 		Biretta_: 10
@@ -5713,6 +5822,7 @@ mob_db: (
 	MoveSpeed: 1000
 	AttackDelay: 1432
 	AttackMotion: 432
+	DamageDelay: 168
 	DamageMotion: 576
 	Drops: {
 		Blossom_Of_Maneater: 9000
@@ -5762,6 +5872,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1540
 	AttackMotion: 720
+	DamageDelay: 303
 	DamageMotion: 432
 	Drops: {
 		Lizard_Scruff: 5500
@@ -5815,6 +5926,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1220
 	AttackMotion: 1080
+	DamageDelay: 315
 	DamageMotion: 648
 	Drops: {
 		Transparent_Cloth: 5335
@@ -5862,6 +5974,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1848
 	AttackMotion: 1296
+	DamageDelay: 450
 	DamageMotion: 432
 	Drops: {
 		Great_Nature: 30
@@ -5912,6 +6025,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1120
 	AttackMotion: 620
+	DamageDelay: 360
 	DamageMotion: 240
 	Drops: {
 		Iron: 270
@@ -5961,6 +6075,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1320
 	AttackMotion: 620
+	DamageDelay: 360
 	DamageMotion: 240
 	Drops: {
 		Iron: 250
@@ -6010,6 +6125,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1624
 	AttackMotion: 624
+	DamageDelay: 360
 	DamageMotion: 240
 	Drops: {
 		Iron: 230
@@ -6059,6 +6175,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1624
 	AttackMotion: 624
+	DamageDelay: 360
 	DamageMotion: 240
 	Drops: {
 		Yellow_Live: 100
@@ -6108,6 +6225,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 3074
 	AttackMotion: 1874
+	DamageDelay: 360
 	DamageMotion: 480
 	Drops: {
 		Iron: 150
@@ -6153,6 +6271,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1480
 	AttackMotion: 480
+	DamageDelay: 270
 	DamageMotion: 720
 	Drops: {
 		Yellow_Live: 120
@@ -6200,6 +6319,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1528
 	AttackMotion: 528
+	DamageDelay: 315
 	DamageMotion: 288
 	Drops: {
 		Yellow_Live: 80
@@ -6248,6 +6368,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1888
 	AttackMotion: 1152
+	DamageDelay: 517
 	DamageMotion: 828
 	Drops: {
 		Stone_Heart: 6500
@@ -6299,6 +6420,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1180
 	AttackMotion: 480
+	DamageDelay: 180
 	DamageMotion: 648
 	Drops: {
 		Pumpkin_Head: 9000
@@ -6349,6 +6471,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1364
 	AttackMotion: 864
+	DamageDelay: 292
 	DamageMotion: 432
 	Drops: {
 		Zargon: 2000
@@ -6400,6 +6523,7 @@ mob_db: (
 	MoveSpeed: 350
 	AttackDelay: 528
 	AttackMotion: 1000
+	DamageDelay: 225
 	DamageMotion: 396
 	Drops: {
 		Skel_Bone: 8000
@@ -6449,6 +6573,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1028
 	AttackMotion: 528
+	DamageDelay: 225
 	DamageMotion: 360
 	Drops: {
 		Steel: 100
@@ -6497,6 +6622,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1528
 	AttackMotion: 528
+	DamageDelay: 225
 	DamageMotion: 360
 	Drops: {
 		Steel: 100
@@ -6545,6 +6671,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1228
 	AttackMotion: 528
+	DamageDelay: 225
 	DamageMotion: 360
 	Drops: {
 		Boody_Red: 35
@@ -6596,6 +6723,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1528
 	AttackMotion: 528
+	DamageDelay: 270
 	DamageMotion: 360
 	Drops: {
 		Steel: 50
@@ -6647,6 +6775,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1228
 	AttackMotion: 528
+	DamageDelay: 270
 	DamageMotion: 360
 	Drops: {
 		Steel: 40
@@ -6694,6 +6823,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1560
 	AttackMotion: 360
+	DamageDelay: 180
 	DamageMotion: 360
 	Drops: {
 		Old_Frying_Pan: 9000
@@ -6744,6 +6874,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1528
 	AttackMotion: 660
+	DamageDelay: 315
 	DamageMotion: 432
 	Drops: {
 		Yellow_Live: 110
@@ -6793,6 +6924,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1540
 	AttackMotion: 840
+	DamageDelay: 405
 	DamageMotion: 504
 	Drops: {
 		Flame_Heart: 35
@@ -6838,6 +6970,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 2280
 	AttackMotion: 1080
+	DamageDelay: 675
 	DamageMotion: 864
 	Drops: {
 		Single_Cell: 5000
@@ -6878,6 +7011,7 @@ mob_db: (
 	MoveSpeed: 800
 	AttackDelay: 1201
 	AttackMotion: 1
+	DamageDelay: 225
 	DamageMotion: 1
 	Drops: {
 		Tendon: 5000
@@ -6927,6 +7061,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1480
 	AttackMotion: 480
+	DamageDelay: 225
 	DamageMotion: 1056
 	Drops: {
 		Golden_Hair: 9000
@@ -6973,6 +7108,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1956
 	AttackMotion: 756
+	DamageDelay: 438
 	DamageMotion: 528
 	Drops: {
 		Chinese_Ink: 9000
@@ -7018,6 +7154,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1480
 	AttackMotion: 480
+	DamageDelay: 180
 	DamageMotion: 480
 	Drops: {
 		Moustache_Of_Mole: 9000
@@ -7067,6 +7204,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 432
 	AttackMotion: 432
+	DamageDelay: 135
 	DamageMotion: 360
 	Drops: {
 		Matyrs_Flea_Guard: 10
@@ -7119,6 +7257,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 864
 	AttackMotion: 1000
+	DamageDelay: 585
 	DamageMotion: 480
 	MvpExp: 21450
 	MvpDrops: {
@@ -7177,6 +7316,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 1720
 	AttackMotion: 1320
+	DamageDelay: 1012
 	DamageMotion: 360
 	Drops: {
 		Slender_Snake: 5335
@@ -7226,6 +7366,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1360
 	AttackMotion: 960
+	DamageDelay: 540
 	DamageMotion: 432
 	Drops: {
 		Nose_Ring: 5335
@@ -7279,6 +7420,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1276
 	AttackMotion: 576
+	DamageDelay: 112
 	DamageMotion: 288
 	MvpExp: 13750
 	MvpDrops: {
@@ -7336,6 +7478,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1576
 	AttackMotion: 576
+	DamageDelay: 315
 	DamageMotion: 384
 	Drops: {
 		Gas_Mask: 2
@@ -7385,6 +7528,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 2420
 	AttackMotion: 720
+	DamageDelay: 270
 	DamageMotion: 648
 	Drops: {
 		Orcish_Cuspid: 5500
@@ -7433,6 +7577,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 2852
 	AttackMotion: 1152
+	DamageDelay: 720
 	DamageMotion: 840
 	Drops: {
 		Nail_Of_Orc: 5500
@@ -7478,6 +7623,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 976
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Vroken_Sword: 4365
@@ -7526,6 +7672,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1624
 	AttackMotion: 620
+	DamageDelay: 315
 	DamageMotion: 384
 	Drops: {
 		Dragon_Canine: 5335
@@ -7575,6 +7722,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1420
 	AttackMotion: 1080
+	DamageDelay: 315
 	DamageMotion: 528
 	Drops: {
 		Dragon_Scale: 5335
@@ -7628,6 +7776,7 @@ mob_db: (
 	MoveSpeed: 125
 	AttackDelay: 868
 	AttackMotion: 768
+	DamageDelay: 540
 	DamageMotion: 288
 	MvpExp: 57495
 	MvpDrops: {
@@ -7680,6 +7829,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 2544
 	AttackMotion: 1344
+	DamageDelay: 405
 	DamageMotion: 1152
 	Drops: {
 		Fish_Tail: 5500
@@ -7732,6 +7882,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1020
 	AttackMotion: 1020
+	DamageDelay: 303
 	DamageMotion: 288
 	MvpExp: 16087
 	MvpDrops: {
@@ -7787,6 +7938,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 135
 	DamageMotion: 576
 	Drops: {
 		Worm_Peelings: 9000
@@ -7832,6 +7984,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 2208
 	AttackMotion: 1008
+	DamageDelay: 540
 	DamageMotion: 324
 	Drops: {
 		Single_Cell: 9000
@@ -7881,6 +8034,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 512
 	AttackMotion: 528
+	DamageDelay: 405
 	DamageMotion: 240
 	Drops: {
 		Root_Of_Maneater: 5500
@@ -7930,6 +8084,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 824
 	AttackMotion: 780
+	DamageDelay: 360
 	DamageMotion: 420
 	Drops: {
 		Elunium: 106
@@ -7979,6 +8134,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1516
 	AttackMotion: 816
+	DamageDelay: 405
 	DamageMotion: 432
 	Drops: {
 		Old_Blue_Box: 35
@@ -8028,6 +8184,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1672
 	AttackMotion: 720
+	DamageDelay: 630
 	DamageMotion: 288
 	Drops: {
 		Great_Nature: 35
@@ -8074,6 +8231,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1960
 	AttackMotion: 960
+	DamageDelay: 180
 	DamageMotion: 384
 	Drops: {
 		Wild_Boars_Mane: 9000
@@ -8119,6 +8277,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1624
 	AttackMotion: 624
+	DamageDelay: 292
 	DamageMotion: 576
 	Drops: {
 		Animals_Skin: 9000
@@ -8167,6 +8326,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1700
 	AttackMotion: 1000
+	DamageDelay: 360
 	DamageMotion: 500
 	Drops: {
 		Flame_Heart: 45
@@ -8215,6 +8375,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 2420
 	AttackMotion: 720
+	DamageDelay: 405
 	DamageMotion: 384
 	Drops: {
 		Iron: 400
@@ -8262,6 +8423,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 2112
 	AttackMotion: 912
+	DamageDelay: 303
 	DamageMotion: 576
 	Drops: {
 		Long_Hair: 9000
@@ -8453,6 +8615,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1688
 	AttackMotion: 1188
+	DamageDelay: 675
 	DamageMotion: 612
 	Drops: {
 		Wind_Of_Verdure: 70
@@ -8499,6 +8662,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1744
 	AttackMotion: 1044
+	DamageDelay: 236
 	DamageMotion: 684
 	Drops: {
 		Rat_Tail: 9000
@@ -8544,6 +8708,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1768
 	AttackMotion: 768
+	DamageDelay: 540
 	DamageMotion: 384
 	Drops: {
 		Yellow_Live: 90
@@ -8590,6 +8755,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1180
 	AttackMotion: 480
+	DamageDelay: 270
 	DamageMotion: 360
 	Drops: {
 		Tooth_Of_: 5500
@@ -8638,6 +8804,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1780
 	AttackMotion: 1080
+	DamageDelay: 675
 	DamageMotion: 432
 	Drops: {
 		Emveretarcon: 55
@@ -8688,6 +8855,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1960
 	AttackMotion: 960
+	DamageDelay: 675
 	DamageMotion: 504
 	Drops: {
 		Sparkling_Dust: 150
@@ -8736,6 +8904,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 840
 	AttackMotion: 540
+	DamageDelay: 337
 	DamageMotion: 480
 	Drops: {
 		Fox_Tail: 4656
@@ -8867,6 +9036,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1076
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Iron: 50
@@ -8916,6 +9086,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1672
 	AttackMotion: 672
+	DamageDelay: 180
 	DamageMotion: 480
 	Drops: {
 		Fluff: 2000
@@ -8956,6 +9127,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1960
 	AttackMotion: 960
+	DamageDelay: 675
 	DamageMotion: 504
 	Drops: {
 		Sparkling_Dust: 10
@@ -9003,6 +9175,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 2536
 	AttackMotion: 1536
+	DamageDelay: 1440
 	DamageMotion: 672
 	Drops: {
 		Sparkling_Dust: 150
@@ -9080,6 +9253,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1720
 	AttackMotion: 500
+	DamageDelay: 1080
 	DamageMotion: 420
 	Drops: {
 		Short_Daenggie: 5500
@@ -9129,6 +9303,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1960
 	AttackMotion: 620
+	DamageDelay: 810
 	DamageMotion: 480
 	Drops: {
 		Sharpened_Cuspid: 4656
@@ -9182,6 +9357,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1248
 	AttackMotion: 500
+	DamageDelay: 585
 	DamageMotion: 360
 	MvpExp: 31102
 	MvpDrops: {
@@ -9236,6 +9412,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 972
 	AttackMotion: 500
+	DamageDelay: 450
 	DamageMotion: 288
 	Drops: {
 		Old_Violet_Box: 5
@@ -9287,6 +9464,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1816
 	AttackMotion: 576
+	DamageDelay: 360
 	DamageMotion: 240
 	Drops: {
 		Transparent_Cloth: 5820
@@ -9338,6 +9516,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1020
 	AttackMotion: 500
+	DamageDelay: 506
 	DamageMotion: 768
 	Drops: {
 		Needle_Of_Alarm: 5335
@@ -9389,6 +9568,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 960
 	AttackMotion: 500
+	DamageDelay: 450
 	DamageMotion: 480
 	Drops: {
 		Round_Shell: 3500
@@ -9440,6 +9620,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 864
 	AttackMotion: 500
+	DamageDelay: 438
 	DamageMotion: 192
 	Drops: {
 		Worn_Out_Page: 4850
@@ -9489,6 +9670,7 @@ mob_db: (
 	MoveSpeed: 350
 	AttackDelay: 1848
 	AttackMotion: 500
+	DamageDelay: 810
 	DamageMotion: 576
 	Drops: {
 		Manacles: 3500
@@ -9538,6 +9720,7 @@ mob_db: (
 	MoveSpeed: 350
 	AttackDelay: 1768
 	AttackMotion: 500
+	DamageDelay: 450
 	DamageMotion: 192
 	Drops: {
 		Worn_Out_Prison_Uniform: 3500
@@ -9589,6 +9772,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 864
 	AttackMotion: 1252
+	DamageDelay: 360
 	DamageMotion: 476
 	Drops: {
 		Book_Of_The_Apocalypse: 5
@@ -9638,6 +9822,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1500
 	AttackMotion: 500
+	DamageDelay: 1080
 	DamageMotion: 1000
 	Drops: {
 		Mould_Powder: 5335
@@ -9688,6 +9873,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 800
 	AttackMotion: 2112
+	DamageDelay: 1980
 	DamageMotion: 768
 	Drops: {
 		Executioners_Mitten: 5
@@ -9738,6 +9924,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1790
 	AttackMotion: 1440
+	DamageDelay: 843
 	DamageMotion: 540
 	Drops: {
 		Thin_N_Long_Tongue: 3880
@@ -9787,6 +9974,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 1744
 	AttackMotion: 1344
+	DamageDelay: 900
 	DamageMotion: 600
 	Drops: {
 		Thin_N_Long_Tongue: 3880
@@ -9838,6 +10026,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1152
 	AttackMotion: 500
+	DamageDelay: 720
 	DamageMotion: 240
 	Drops: {
 		Lokis_Whispers: 1
@@ -9892,6 +10081,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 816
 	AttackMotion: 500
+	DamageDelay: 540
 	DamageMotion: 240
 	Drops: {
 		Old_Hilt: 1
@@ -9945,6 +10135,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 768
 	AttackMotion: 500
+	DamageDelay: 450
 	DamageMotion: 384
 	Drops: {
 		Bloody_Edge: 5
@@ -9996,6 +10187,7 @@ mob_db: (
 	MoveSpeed: 190
 	AttackDelay: 900
 	AttackMotion: 500
+	DamageDelay: 618
 	DamageMotion: 864
 	Drops: {
 		Anolian_Skin: 4850
@@ -10047,6 +10239,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 528
 	AttackMotion: 500
+	DamageDelay: 315
 	DamageMotion: 240
 	Drops: {
 		Mud_Lump: 4850
@@ -10100,6 +10293,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 672
 	AttackMotion: 500
+	DamageDelay: 630
 	DamageMotion: 192
 	Drops: {
 		Skull: 4850
@@ -10149,6 +10343,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1000
 	AttackMotion: 500
+	DamageDelay: 607
 	DamageMotion: 1000
 	Drops: {
 		Claw_Of_Rat: 4656
@@ -10248,6 +10443,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1500
 	AttackMotion: 500
+	DamageDelay: 675
 	DamageMotion: 1000
 	Drops: {
 		Glitter_Shell: 5335
@@ -10298,6 +10494,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1500
 	AttackMotion: 500
+	DamageDelay: 360
 	DamageMotion: 1000
 	Drops: {
 		Tail_Of_Steel_Scorpion: 5335
@@ -10348,6 +10545,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1500
 	AttackMotion: 500
+	DamageDelay: 405
 	DamageMotion: 1000
 	Drops: {
 		Ogre_Tooth: 2500
@@ -10397,6 +10595,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1500
 	AttackMotion: 500
+	DamageDelay: 472
 	DamageMotion: 1000
 	Drops: {
 		Claw_Of_Monkey: 5335
@@ -10446,6 +10645,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1500
 	AttackMotion: 500
+	DamageDelay: 270
 	DamageMotion: 1000
 	Drops: {
 		Tough_Scalelike_Stem: 5335
@@ -10497,6 +10697,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 832
 	AttackMotion: 500
+	DamageDelay: 315
 	DamageMotion: 600
 	Drops: {
 		Coral_Reef: 4850
@@ -10549,6 +10750,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1500
 	AttackMotion: 500
+	DamageDelay: 675
 	DamageMotion: 1000
 	Drops: {
 		Reins: 5335
@@ -11639,6 +11841,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Garlet: 3200
@@ -11690,6 +11893,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1260
 	AttackMotion: 192
+	DamageDelay: 1181
 	DamageMotion: 192
 	Drops: {
 		Zargon: 750
@@ -11735,6 +11939,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1180
 	AttackMotion: 480
+	DamageDelay: 180
 	DamageMotion: 648
 	Drops: {
 		Pumpkin_Head: 5335
@@ -11780,6 +11985,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1120
 	AttackMotion: 620
+	DamageDelay: 360
 	DamageMotion: 240
 	Drops: {
 		Packing_Ribbon: 550
@@ -11826,6 +12032,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1248
 	AttackMotion: 1248
+	DamageDelay: 315
 	DamageMotion: 240
 	Drops: {
 		Well_Baked_Cookie: 1500
@@ -11872,6 +12079,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 720
 	AttackMotion: 720
+	DamageDelay: 405
 	DamageMotion: 432
 	Drops: {
 		Red_Socks_With_Holes: 10000
@@ -11919,6 +12127,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1296
 	AttackMotion: 1296
+	DamageDelay: 1215
 	DamageMotion: 432
 	Drops: {
 		Manacles: 900
@@ -11965,6 +12174,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1248
 	AttackMotion: 1248
+	DamageDelay: 405
 	DamageMotion: 432
 	Drops: {
 		Candy_Striper: 90
@@ -12016,6 +12226,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 672
 	AttackMotion: 672
+	DamageDelay: 315
 	DamageMotion: 288
 	Drops: {
 		Matchstick: 2500
@@ -12070,6 +12281,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 468
 	AttackMotion: 468
+	DamageDelay: 236
 	DamageMotion: 288
 	MvpExp: 32175
 	MvpDrops: {
@@ -12130,6 +12342,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 608
 	AttackMotion: 408
+	DamageDelay: 292
 	DamageMotion: 336
 	MvpExp: 25025
 	MvpDrops: {
@@ -12183,6 +12396,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1020
 	AttackMotion: 720
+	DamageDelay: 562
 	DamageMotion: 384
 	Drops: {
 		Zargon: 3880
@@ -12232,6 +12446,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1000
 	AttackMotion: 900
+	DamageDelay: 236
 	DamageMotion: 384
 	Drops: {
 		Cyfar: 3000
@@ -12284,6 +12499,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 776
 	AttackMotion: 576
+	DamageDelay: 360
 	DamageMotion: 288
 	Drops: {
 		Earthworm_Peeling: 5100
@@ -12335,6 +12551,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 700
 	AttackMotion: 648
+	DamageDelay: 371
 	DamageMotion: 480
 	Drops: {
 		Earthworm_Peeling: 5500
@@ -12385,6 +12602,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 770
 	AttackMotion: 720
+	DamageDelay: 506
 	DamageMotion: 336
 	Drops: {
 		Steel: 300
@@ -12432,6 +12650,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1172
 	AttackMotion: 672
+	DamageDelay: 495
 	DamageMotion: 420
 	Drops: {
 		Goblini_Mask: 3
@@ -12485,6 +12704,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 704
 	AttackMotion: 504
+	DamageDelay: 270
 	DamageMotion: 432
 	Drops: {
 		Talon_Of_Griffin: 2500
@@ -12537,6 +12757,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 920
 	AttackMotion: 720
+	DamageDelay: 337
 	DamageMotion: 200
 	Drops: {
 		Brigan: 4656
@@ -12581,6 +12802,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 964
 	AttackMotion: 864
+	DamageDelay: 787
 	DamageMotion: 288
 	Drops: {
 		Cyfar: 5335
@@ -12635,6 +12857,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1280
 	AttackMotion: 1080
+	DamageDelay: 843
 	DamageMotion: 240
 	Drops: {
 		Brigan: 4850
@@ -12687,6 +12910,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1056
 	AttackMotion: 1056
+	DamageDelay: 675
 	DamageMotion: 336
 	Drops: {
 		Zargon: 4559
@@ -12738,6 +12962,7 @@ mob_db: (
 	MoveSpeed: 220
 	AttackDelay: 916
 	AttackMotion: 816
+	DamageDelay: 360
 	DamageMotion: 336
 	Drops: {
 		Lip_Of_Ancient_Fish: 1300
@@ -12785,6 +13010,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1036
 	AttackMotion: 936
+	DamageDelay: 101
 	DamageMotion: 240
 	Drops: {
 		Well_Baked_Cookie: 1000
@@ -12831,6 +13057,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1264
 	AttackMotion: 864
+	DamageDelay: 315
 	DamageMotion: 216
 	Drops: {
 		Sticky_Mucus: 500
@@ -12882,6 +13109,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1078
 	AttackMotion: 768
+	DamageDelay: 540
 	DamageMotion: 384
 	Drops: {
 		Brigan: 3200
@@ -12931,6 +13159,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 828
 	AttackMotion: 528
+	DamageDelay: 270
 	DamageMotion: 192
 	Drops: {
 		Brigan: 4850
@@ -12977,6 +13206,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1092
 	AttackMotion: 792
+	DamageDelay: 405
 	DamageMotion: 480
 	Drops: {
 		Needle_Of_Alarm: 5335
@@ -13024,6 +13254,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1072
 	AttackMotion: 672
+	DamageDelay: 360
 	DamageMotion: 384
 	Drops: {
 		Needle_Of_Alarm: 5335
@@ -13070,6 +13301,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1100
 	AttackMotion: 900
+	DamageDelay: 506
 	DamageMotion: 480
 	Drops: {
 		Zargon: 1000
@@ -13121,6 +13353,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 868
 	AttackMotion: 768
+	DamageDelay: 382
 	DamageMotion: 480
 	MvpExp: 32890
 	MvpDrops: {
@@ -13178,6 +13411,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1050
 	AttackMotion: 900
+	DamageDelay: 506
 	DamageMotion: 288
 	Drops: {
 		Cyfar: 4656
@@ -13223,6 +13457,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1332
 	AttackMotion: 1332
+	DamageDelay: 877
 	DamageMotion: 672
 	Drops: {
 		Zargon: 100
@@ -13267,6 +13502,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 502
 	AttackMotion: 2304
+	DamageDelay: 2160
 	DamageMotion: 480
 	Drops: {
 		Alices_Apron: 2500
@@ -13315,6 +13551,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1152
 	AttackMotion: 1152
+	DamageDelay: 911
 	DamageMotion: 480
 	Drops: {
 		Brigan: 4656
@@ -13359,6 +13596,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1152
 	AttackMotion: 1152
+	DamageDelay: 765
 	DamageMotion: 384
 	Drops: {
 		Brigan: 2000
@@ -13405,6 +13643,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1264
 	AttackMotion: 864
+	DamageDelay: 810
 	DamageMotion: 288
 	Drops: {
 		Mud_Lump: 2000
@@ -13456,6 +13695,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 860
 	AttackMotion: 660
+	DamageDelay: 618
 	DamageMotion: 624
 	Drops: {
 		Cyfar: 100
@@ -13502,6 +13742,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1008
 	AttackMotion: 1008
+	DamageDelay: 303
 	DamageMotion: 528
 	Drops: {
 		Scell: 2500
@@ -13548,6 +13789,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 936
 	AttackMotion: 936
+	DamageDelay: 472
 	DamageMotion: 288
 	Drops: {
 		Librarian_Glove: 5
@@ -13595,6 +13837,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1008
 	AttackMotion: 1008
+	DamageDelay: 472
 	DamageMotion: 384
 	Drops: {
 		Zargon: 250
@@ -13648,6 +13891,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 772
 	AttackMotion: 672
+	DamageDelay: 360
 	DamageMotion: 360
 	Drops: {
 		Brigan: 5335
@@ -13906,6 +14150,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1024
 	AttackMotion: 1000
+	DamageDelay: 585
 	DamageMotion: 480
 	Drops: {
 		Cyfar: 4413
@@ -13957,6 +14202,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 2276
 	AttackMotion: 576
+	DamageDelay: 202
 	DamageMotion: 432
 	Drops: {
 		Burn_Tree: 2550
@@ -14008,6 +14254,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 1816
 	AttackMotion: 576
+	DamageDelay: 765
 	DamageMotion: 240
 	Drops: {
 		Transparent_Cloth: 4413
@@ -14060,6 +14307,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1000
 	AttackMotion: 600
+	DamageDelay: 1800
 	DamageMotion: 384
 	Drops: {
 		Petite_DiablOfs_Horn: 4413
@@ -14112,6 +14360,7 @@ mob_db: (
 	MoveSpeed: 155
 	AttackDelay: 1136
 	AttackMotion: 720
+	DamageDelay: 405
 	DamageMotion: 840
 	Drops: {
 		Powder_Of_Butterfly: 4550
@@ -14164,6 +14413,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 1528
 	AttackMotion: 660
+	DamageDelay: 225
 	DamageMotion: 432
 	Drops: {
 		Limb_Of_Mantis: 4550
@@ -14217,6 +14467,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 1345
 	AttackMotion: 824
+	DamageDelay: 2340
 	DamageMotion: 440
 	Drops: {
 		Tatters_Clothes: 3500
@@ -14268,6 +14519,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1028
 	AttackMotion: 528
+	DamageDelay: 225
 	DamageMotion: 360
 	Drops: {
 		Steel: 450
@@ -14319,6 +14571,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 1772
 	AttackMotion: 120
+	DamageDelay: 270
 	DamageMotion: 384
 	Drops: {
 		Rotten_Bandage: 4413
@@ -14370,6 +14623,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 2612
 	AttackMotion: 912
+	DamageDelay: 855
 	DamageMotion: 288
 	Drops: {
 		Tatters_Clothes: 4413
@@ -14421,6 +14675,7 @@ mob_db: (
 	MoveSpeed: 120
 	AttackDelay: 1120
 	AttackMotion: 620
+	DamageDelay: 1170
 	DamageMotion: 240
 	Drops: {
 		Brigan: 1500
@@ -14473,6 +14728,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1672
 	AttackMotion: 672
+	DamageDelay: 180
 	DamageMotion: 480
 	Drops: {
 		Feather: 3000
@@ -14525,6 +14781,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1156
 	AttackMotion: 456
+	DamageDelay: 270
 	DamageMotion: 384
 	Drops: {
 		Dokkaebi_Horn: 4550
@@ -14578,6 +14835,7 @@ mob_db: (
 	MoveSpeed: 145
 	AttackDelay: 1024
 	AttackMotion: 768
+	DamageDelay: 5130
 	DamageMotion: 480
 	Drops: {
 		Bone_Wand: 3
@@ -14630,6 +14888,7 @@ mob_db: (
 	MoveSpeed: 155
 	AttackDelay: 1292
 	AttackMotion: 792
+	DamageDelay: 742
 	DamageMotion: 340
 	Drops: {
 		Royal_Jelly: 550
@@ -14682,6 +14941,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1468
 	AttackMotion: 468
+	DamageDelay: 202
 	DamageMotion: 768
 	Drops: {
 		Spiderweb: 4550
@@ -14734,6 +14994,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1792
 	AttackMotion: 792
+	DamageDelay: 540
 	DamageMotion: 336
 	Drops: {
 		Short_Leg: 4413
@@ -14785,6 +15046,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 1260
 	AttackMotion: 230
+	DamageDelay: 1260
 	DamageMotion: 192
 	Drops: {
 		Bears_Foot: 4550
@@ -14838,6 +15100,7 @@ mob_db: (
 	MoveSpeed: 155
 	AttackDelay: 1276
 	AttackMotion: 576
+	DamageDelay: 112
 	DamageMotion: 288
 	Drops: {
 		Puppy_Love: 1
@@ -14889,6 +15152,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 960
 	AttackMotion: 1008
+	DamageDelay: 2520
 	DamageMotion: 840
 	Drops: {
 		Cyfar: 4413
@@ -14940,6 +15204,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1000
 	AttackMotion: 1152
+	DamageDelay: 517
 	DamageMotion: 828
 	Drops: {
 		Stone_Heart: 6500
@@ -14991,6 +15256,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1100
 	AttackMotion: 960
+	DamageDelay: 1800
 	DamageMotion: 780
 	Drops: {
 		Nose_Ring: 4413
@@ -15042,6 +15308,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1960
 	AttackMotion: 960
+	DamageDelay: 180
 	DamageMotion: 384
 	Drops: {
 		Wild_Boars_Mane: 3500
@@ -15095,6 +15362,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 900
 	AttackMotion: 1000
+	DamageDelay: 585
 	DamageMotion: 500
 	MvpExp: 9101
 	MvpDrops: {
@@ -15152,6 +15420,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1100
 	AttackMotion: 560
+	DamageDelay: 630
 	DamageMotion: 580
 	Drops: {
 		Poison_Knife: 3
@@ -15198,6 +15467,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1100
 	AttackMotion: 483
+	DamageDelay: 675
 	DamageMotion: 528
 	Drops: {
 		Turtle_Shell: 4413
@@ -15249,6 +15519,7 @@ mob_db: (
 	MoveSpeed: 155
 	AttackDelay: 1000
 	AttackMotion: 900
+	DamageDelay: 506
 	DamageMotion: 432
 	Drops: {
 		Turtle_Shell: 4413
@@ -15295,6 +15566,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1452
 	AttackMotion: 483
+	DamageDelay: 1350
 	DamageMotion: 528
 	Drops: {
 		Turtle_Shell: 4413
@@ -15345,6 +15617,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1612
 	AttackMotion: 622
+	DamageDelay: 540
 	DamageMotion: 583
 	Drops: {
 		Zargon: 4365
@@ -15396,6 +15669,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1452
 	AttackMotion: 483
+	DamageDelay: 1215
 	DamageMotion: 528
 	Drops: {
 		Turtle_Shell: 4413
@@ -15447,6 +15721,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1452
 	AttackMotion: 483
+	DamageDelay: 506
 	DamageMotion: 528
 	Drops: {
 		Turtle_Shell: 4413
@@ -15500,6 +15775,7 @@ mob_db: (
 	MoveSpeed: 195
 	AttackDelay: 1345
 	AttackMotion: 824
+	DamageDelay: 720
 	DamageMotion: 440
 	Drops: {
 		Tatters_Clothes: 4413
@@ -15552,6 +15828,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 862
 	AttackMotion: 534
+	DamageDelay: 337
 	DamageMotion: 312
 	Drops: {
 		Dragon_Fly_Wing: 4413
@@ -15598,6 +15875,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 1120
 	AttackMotion: 552
+	DamageDelay: 708
 	DamageMotion: 511
 	Drops: {
 		Brigan: 3500
@@ -15647,6 +15925,7 @@ mob_db: (
 	MoveSpeed: 190
 	AttackDelay: 1132
 	AttackMotion: 583
+	DamageDelay: 405
 	DamageMotion: 532
 	Drops: {
 		Scarlet_Jewel: 150
@@ -17499,6 +17778,7 @@ mob_db: (
 	MoveSpeed: 155
 	AttackDelay: 1000
 	AttackMotion: 900
+	DamageDelay: 1350
 	DamageMotion: 432
 	Drops: {
 		Wooden_Block: 9000
@@ -17538,6 +17818,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1840
 	AttackMotion: 1440
+	DamageDelay: 675
 	DamageMotion: 384
 	Drops: {
 		Broken_Steel_Piece: 5335
@@ -17587,6 +17868,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 2190
 	AttackMotion: 2040
+	DamageDelay: 675
 	DamageMotion: 336
 	Drops: {
 		Cold_Magma: 4559
@@ -17637,6 +17919,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 1732
 	AttackMotion: 1332
+	DamageDelay: 438
 	DamageMotion: 540
 	Drops: {
 		Burning_Heart: 4850
@@ -17678,6 +17961,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 1308
 	AttackMotion: 1008
+	DamageDelay: 450
 	DamageMotion: 480
 	Drops: {
 		Blossom_Of_Maneater: 6200
@@ -17723,6 +18007,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1460
 	AttackMotion: 960
+	DamageDelay: 2340
 	DamageMotion: 432
 	Drops: {
 		Peco_Wing_Feather: 4850
@@ -17773,6 +18058,7 @@ mob_db: (
 	MoveSpeed: 155
 	AttackDelay: 1306
 	AttackMotion: 1056
+	DamageDelay: 540
 	DamageMotion: 288
 	Drops: {
 		Fruit_Of_Mastela: 1500
@@ -17823,6 +18109,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 920
 	AttackMotion: 720
+	DamageDelay: 393
 	DamageMotion: 336
 	Drops: {
 		Blue_Gemstone: 1000
@@ -17868,6 +18155,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1380
 	AttackMotion: 1080
+	DamageDelay: 675
 	DamageMotion: 336
 	Drops: {
 		Goats_Horn: 4559
@@ -17922,6 +18210,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 1446
 	AttackMotion: 1296
+	DamageDelay: 720
 	DamageMotion: 360
 	MvpExp: 65671
 	MvpDrops: {
@@ -17980,6 +18269,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 850
 	AttackMotion: 600
+	DamageDelay: 393
 	DamageMotion: 336
 	Drops: {
 		Fruit_Of_Mastela: 1500
@@ -18029,6 +18319,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 1160
 	AttackMotion: 960
+	DamageDelay: 506
 	DamageMotion: 336
 	Drops: {
 		Smooth_Paper: 4947
@@ -18077,6 +18368,7 @@ mob_db: (
 	MoveSpeed: 155
 	AttackDelay: 972
 	AttackMotion: 672
+	DamageDelay: 360
 	DamageMotion: 470
 	Drops: {
 		Harpys_Feather: 4850
@@ -18125,6 +18417,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1552
 	AttackMotion: 1152
+	DamageDelay: 675
 	DamageMotion: 336
 	Drops: {
 		Old_Magic_Circle: 4000
@@ -18175,6 +18468,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 1260
 	AttackMotion: 960
+	DamageDelay: 630
 	DamageMotion: 672
 	Drops: {
 		Spawns: 4074
@@ -18222,6 +18516,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1216
 	AttackMotion: 816
+	DamageDelay: 765
 	DamageMotion: 432
 	Drops: {
 		Burning_Horse_Shoe: 4947
@@ -18271,6 +18566,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1300
 	AttackMotion: 900
+	DamageDelay: 506
 	DamageMotion: 336
 	Drops: {
 		Lizard_Scruff: 7500
@@ -18316,6 +18612,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1492
 	AttackMotion: 1092
+	DamageDelay: 787
 	DamageMotion: 192
 	Drops: {
 		Bears_Foot: 5000
@@ -18362,6 +18659,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1080
 	AttackMotion: 780
+	DamageDelay: 810
 	DamageMotion: 180
 	Drops: {
 		Petite_DiablOfs_Horn: 5820
@@ -18409,6 +18707,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1260
 	AttackMotion: 960
+	DamageDelay: 450
 	DamageMotion: 336
 	Drops: {
 		Wing_Of_Red_Bat: 5500
@@ -18456,6 +18755,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 1020
 	AttackMotion: 720
+	DamageDelay: 315
 	DamageMotion: 384
 	Drops: {
 		Dragons_Skin: 4074
@@ -18502,6 +18802,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 1024
 	AttackMotion: 624
+	DamageDelay: 315
 	DamageMotion: 336
 	Drops: {
 		Dragons_Skin: 4074
@@ -18548,6 +18849,7 @@ mob_db: (
 	MoveSpeed: 195
 	AttackDelay: 1350
 	AttackMotion: 1200
+	DamageDelay: 675
 	DamageMotion: 432
 	Drops: {
 		Sand_Lump: 4947
@@ -18597,6 +18899,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 1264
 	AttackMotion: 864
+	DamageDelay: 360
 	DamageMotion: 576
 	Drops: {
 		Scropions_Nipper: 4365
@@ -18649,6 +18952,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 1072
 	AttackMotion: 672
+	DamageDelay: 292
 	DamageMotion: 480
 	Drops: {
 		Satanic_Chain: 5
@@ -18702,6 +19006,7 @@ mob_db: (
 	MoveSpeed: 145
 	AttackDelay: 1290
 	AttackMotion: 1140
+	DamageDelay: 731
 	DamageMotion: 576
 	MvpExp: 60078
 	MvpDrops: {
@@ -18754,6 +19059,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 1356
 	AttackMotion: 1056
+	DamageDelay: 225
 	DamageMotion: 540
 	Drops: {
 		Golden_Hair: 6305
@@ -18802,6 +19108,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1430
 	AttackMotion: 1080
+	DamageDelay: 450
 	DamageMotion: 1080
 	Drops: {
 		Cyfar: 5335
@@ -18849,6 +19156,7 @@ mob_db: (
 	MoveSpeed: 155
 	AttackDelay: 2416
 	AttackMotion: 2016
+	DamageDelay: 945
 	DamageMotion: 432
 	Drops: {
 		Large_Jellopy: 500
@@ -18898,6 +19206,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1772
 	AttackMotion: 72
+	DamageDelay: 270
 	DamageMotion: 384
 },
 {
@@ -18937,6 +19246,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 2612
 	AttackMotion: 912
+	DamageDelay: 855
 	DamageMotion: 288
 },
 {
@@ -18974,6 +19284,7 @@ mob_db: (
 	MoveSpeed: 190
 	AttackDelay: 0
 	AttackMotion: 0
+	DamageDelay: 1080
 	DamageMotion: 0
 	Drops: {
 		Piece_Of_Cake: 3800
@@ -19021,6 +19332,7 @@ mob_db: (
 	MoveSpeed: 190
 	AttackDelay: 0
 	AttackMotion: 0
+	DamageDelay: 1080
 	DamageMotion: 0
 	Drops: {
 		Piece_Of_Cake: 3800
@@ -19068,6 +19380,7 @@ mob_db: (
 	MoveSpeed: 190
 	AttackDelay: 0
 	AttackMotion: 0
+	DamageDelay: 1080
 	DamageMotion: 0
 	Drops: {
 		Piece_Of_Cake: 3800
@@ -19115,6 +19428,7 @@ mob_db: (
 	MoveSpeed: 190
 	AttackDelay: 0
 	AttackMotion: 0
+	DamageDelay: 1080
 	DamageMotion: 0
 	Drops: {
 		Piece_Of_Cake: 3800
@@ -19168,6 +19482,7 @@ mob_db: (
 	MoveSpeed: 130
 	AttackDelay: 768
 	AttackMotion: 768
+	DamageDelay: 360
 	DamageMotion: 576
 	MvpExp: 130875
 	MvpDrops: {
@@ -19219,6 +19534,7 @@ mob_db: (
 	MoveSpeed: 155
 	AttackDelay: 1638
 	AttackMotion: 2016
+	DamageDelay: 405
 	DamageMotion: 576
 	Drops: {
 		Oil_Paper: 5000
@@ -19270,6 +19586,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1003
 	AttackMotion: 1152
+	DamageDelay: 2160
 	DamageMotion: 336
 	Drops: {
 		Broken_Shuriken: 5335
@@ -19316,6 +19633,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 1148
 	AttackMotion: 1728
+	DamageDelay: 585
 	DamageMotion: 864
 	Drops: {
 		Poison_Toads_Skin: 5500
@@ -19364,6 +19682,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 1084
 	AttackMotion: 2304
+	DamageDelay: 450
 	DamageMotion: 576
 	Drops: {
 		Iron: 5500
@@ -19412,6 +19731,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1938
 	AttackMotion: 2112
+	DamageDelay: 1980
 	DamageMotion: 768
 	Drops: {
 		Glossy_Hair: 5335
@@ -19462,6 +19782,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1439
 	AttackMotion: 1920
+	DamageDelay: 585
 	DamageMotion: 672
 	Drops: {
 		Tengus_Nose: 3500
@@ -19511,6 +19832,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 2012
 	AttackMotion: 1728
+	DamageDelay: 540
 	DamageMotion: 672
 	Drops: {
 		Yellow_Plate: 6500
@@ -19592,6 +19914,7 @@ mob_db: (
 	MoveSpeed: 145
 	AttackDelay: 472
 	AttackMotion: 576
+	DamageDelay: 450
 	DamageMotion: 288
 	Drops: {
 		Sharp_Feeler: 4608
@@ -19638,6 +19961,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 647
 	AttackMotion: 768
+	DamageDelay: 315
 	DamageMotion: 420
 	Drops: {
 		Bamboo_Cut: 3200
@@ -19685,6 +20009,7 @@ mob_db: (
 	MoveSpeed: 410
 	AttackDelay: 400
 	AttackMotion: 672
+	DamageDelay: 630
 	DamageMotion: 480
 	Drops: {
 		Hard_Peach: 4365
@@ -19724,6 +20049,7 @@ mob_db: (
 	MoveSpeed: 0
 	AttackDelay: 0
 	AttackMotion: 0
+	DamageDelay: 0
 	DamageMotion: 0
 },*/
 {
@@ -19762,6 +20088,7 @@ mob_db: (
 	MoveSpeed: 190
 	AttackDelay: 480
 	AttackMotion: 840
+	DamageDelay: 585
 	DamageMotion: 432
 	Drops: {
 		Cloud_Piece: 4656
@@ -19809,6 +20136,7 @@ mob_db: (
 	MoveSpeed: 140
 	AttackDelay: 512
 	AttackMotion: 756
+	DamageDelay: 506
 	DamageMotion: 360
 	Drops: {
 		Leaflet_Of_Hinal: 3500
@@ -19850,6 +20178,7 @@ mob_db: (
 	MoveSpeed: 0
 	AttackDelay: 0
 	AttackMotion: 0
+	DamageDelay: 0
 	DamageMotion: 0
 },*/
 {
@@ -19889,6 +20218,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 318
 	AttackMotion: 528
+	DamageDelay: 225
 	DamageMotion: 420
 	Drops: {
 		Leopard_Skin: 5200
@@ -19941,6 +20271,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 637
 	AttackMotion: 1008
+	DamageDelay: 540
 	DamageMotion: 360
 	Drops: {
 		Limpid_Celestial_Robe: 3977
@@ -19987,6 +20318,7 @@ mob_db: (
 	MoveSpeed: 155
 	AttackDelay: 780
 	AttackMotion: 1008
+	DamageDelay: 270
 	DamageMotion: 420
 	Drops: {
 		Black_Bears_Skin: 4462
@@ -20038,6 +20370,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 588
 	AttackMotion: 816
+	DamageDelay: 1530
 	DamageMotion: 420
 	MvpExp: 17144
 	MvpDrops: {
@@ -20093,6 +20426,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1276
 	AttackMotion: 576
+	DamageDelay: 540
 	DamageMotion: 384
 },
 {
@@ -20132,6 +20466,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 2864
 	AttackMotion: 864
+	DamageDelay: 630
 	DamageMotion: 576
 },
 {
@@ -20172,6 +20507,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1384
 	AttackMotion: 768
+	DamageDelay: 450
 	DamageMotion: 336
 },
 {
@@ -20212,6 +20548,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 676
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 480
 },
 {
@@ -20251,6 +20588,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 2456
 	AttackMotion: 912
+	DamageDelay: 427
 	DamageMotion: 504
 },
 {
@@ -20290,6 +20628,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1576
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 576
 },
 {
@@ -20329,6 +20668,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 360
 	DamageMotion: 288
 },
 {
@@ -20368,6 +20708,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1272
 	AttackMotion: 72
+	DamageDelay: 202
 	DamageMotion: 480
 },
 {
@@ -20408,6 +20749,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1816
 	AttackMotion: 816
+	DamageDelay: 765
 	DamageMotion: 432
 },
 {
@@ -20447,6 +20789,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1672
 	AttackMotion: 672
+	DamageDelay: 630
 	DamageMotion: 288
 },
 {
@@ -20487,6 +20830,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1792
 	AttackMotion: 792
+	DamageDelay: 540
 	DamageMotion: 336
 },
 {
@@ -20527,6 +20871,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1468
 	AttackMotion: 468
+	DamageDelay: 202
 	DamageMotion: 768
 },
 {
@@ -20567,6 +20912,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 868
 	AttackMotion: 480
+	DamageDelay: 540
 	DamageMotion: 120
 },
 {
@@ -20606,6 +20952,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1120
 	AttackMotion: 420
+	DamageDelay: 168
 	DamageMotion: 288
 },
 {
@@ -20646,6 +20993,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 980
 	AttackMotion: 600
+	DamageDelay: 270
 	DamageMotion: 384
 },
 {
@@ -20685,6 +21033,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1276
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 384
 },
 {
@@ -20724,6 +21073,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 2276
 	AttackMotion: 576
+	DamageDelay: 157
 	DamageMotion: 336
 },
 {
@@ -20763,6 +21113,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1180
 	AttackMotion: 480
+	DamageDelay: 180
 	DamageMotion: 648
 },
 {
@@ -20802,6 +21153,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1364
 	AttackMotion: 864
+	DamageDelay: 292
 	DamageMotion: 432
 },
 {
@@ -20841,6 +21193,7 @@ mob_db: (
 	MoveSpeed: 350
 	AttackDelay: 528
 	AttackMotion: 1000
+	DamageDelay: 225
 	DamageMotion: 396
 },
 {
@@ -20880,6 +21233,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1500
 	AttackMotion: 500
+	DamageDelay: 405
 	DamageMotion: 1000
 },
 {
@@ -20919,6 +21273,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1500
 	AttackMotion: 500
+	DamageDelay: 270
 	DamageMotion: 1000
 },
 {
@@ -20958,6 +21313,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 832
 	AttackMotion: 500
+	DamageDelay: 315
 	DamageMotion: 600
 },
 {
@@ -20997,6 +21353,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1260
 	AttackMotion: 192
+	DamageDelay: 1181
 	DamageMotion: 192
 },
 {
@@ -21036,6 +21393,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1296
 	AttackMotion: 1296
+	DamageDelay: 1215
 	DamageMotion: 432
 },
 {
@@ -21075,6 +21433,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 672
 	AttackMotion: 672
+	DamageDelay: 315
 	DamageMotion: 288
 },
 {
@@ -21114,6 +21473,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1000
 	AttackMotion: 900
+	DamageDelay: 236
 	DamageMotion: 384
 },
 {
@@ -21153,6 +21513,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 770
 	AttackMotion: 720
+	DamageDelay: 506
 	DamageMotion: 336
 },
 {
@@ -21194,6 +21555,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 704
 	AttackMotion: 504
+	DamageDelay: 270
 	DamageMotion: 432
 },
 {
@@ -21234,6 +21596,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 920
 	AttackMotion: 720
+	DamageDelay: 337
 	DamageMotion: 200
 },
 {
@@ -21276,6 +21639,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1280
 	AttackMotion: 1080
+	DamageDelay: 843
 	DamageMotion: 240
 },
 {
@@ -21316,6 +21680,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1056
 	AttackMotion: 1056
+	DamageDelay: 675
 	DamageMotion: 336
 },
 {
@@ -21355,6 +21720,7 @@ mob_db: (
 	MoveSpeed: 220
 	AttackDelay: 916
 	AttackMotion: 816
+	DamageDelay: 360
 	DamageMotion: 336
 },
 {
@@ -21394,6 +21760,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1050
 	AttackMotion: 900
+	DamageDelay: 506
 	DamageMotion: 288
 },
 {
@@ -21434,6 +21801,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1152
 	AttackMotion: 1152
+	DamageDelay: 911
 	DamageMotion: 480
 },
 {
@@ -21474,6 +21842,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 860
 	AttackMotion: 660
+	DamageDelay: 618
 	DamageMotion: 624
 },
 {
@@ -21513,6 +21882,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1008
 	AttackMotion: 1008
+	DamageDelay: 472
 	DamageMotion: 384
 },
 {
@@ -21554,6 +21924,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 772
 	AttackMotion: 672
+	DamageDelay: 360
 	DamageMotion: 360
 },
 {
@@ -21594,6 +21965,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1528
 	AttackMotion: 660
+	DamageDelay: 315
 	DamageMotion: 432
 },
 {
@@ -21633,6 +22005,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1540
 	AttackMotion: 840
+	DamageDelay: 405
 	DamageMotion: 504
 },
 {
@@ -21673,6 +22046,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1480
 	AttackMotion: 480
+	DamageDelay: 225
 	DamageMotion: 1056
 },
 {
@@ -21712,6 +22086,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 432
 	AttackMotion: 432
+	DamageDelay: 135
 	DamageMotion: 360
 },
 {
@@ -21751,6 +22126,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1360
 	AttackMotion: 960
+	DamageDelay: 540
 	DamageMotion: 432
 },
 {
@@ -21790,6 +22166,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 2420
 	AttackMotion: 720
+	DamageDelay: 270
 	DamageMotion: 648
 },
 {
@@ -21829,6 +22206,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 2852
 	AttackMotion: 1152
+	DamageDelay: 720
 	DamageMotion: 840
 },
 {
@@ -21868,6 +22246,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 976
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 288
 },
 {
@@ -21907,6 +22286,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1624
 	AttackMotion: 620
+	DamageDelay: 315
 	DamageMotion: 384
 },
 {
@@ -21946,6 +22326,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1420
 	AttackMotion: 1080
+	DamageDelay: 315
 	DamageMotion: 528
 },
 {
@@ -21985,6 +22366,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 824
 	AttackMotion: 780
+	DamageDelay: 360
 	DamageMotion: 420
 },
 {
@@ -22025,6 +22407,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1516
 	AttackMotion: 816
+	DamageDelay: 405
 	DamageMotion: 432
 },
 {
@@ -22064,6 +22447,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 2420
 	AttackMotion: 720
+	DamageDelay: 405
 	DamageMotion: 384
 },
 {
@@ -22103,6 +22487,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1780
 	AttackMotion: 1080
+	DamageDelay: 675
 	DamageMotion: 432
 },
 {
@@ -22142,6 +22527,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 840
 	AttackMotion: 540
+	DamageDelay: 337
 	DamageMotion: 480
 },
 {
@@ -22181,6 +22567,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1720
 	AttackMotion: 500
+	DamageDelay: 1080
 	DamageMotion: 420
 },
 {
@@ -22220,6 +22607,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1960
 	AttackMotion: 620
+	DamageDelay: 810
 	DamageMotion: 480
 },
 {
@@ -22259,6 +22647,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 972
 	AttackMotion: 500
+	DamageDelay: 450
 	DamageMotion: 288
 },
 {
@@ -22298,6 +22687,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1816
 	AttackMotion: 576
+	DamageDelay: 360
 	DamageMotion: 240
 },
 {
@@ -22337,6 +22727,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1020
 	AttackMotion: 500
+	DamageDelay: 506
 	DamageMotion: 768
 },
 {
@@ -22378,6 +22769,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 960
 	AttackMotion: 500
+	DamageDelay: 450
 	DamageMotion: 480
 },
 {
@@ -22417,6 +22809,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 864
 	AttackMotion: 500
+	DamageDelay: 438
 	DamageMotion: 192
 },
 {
@@ -22456,6 +22849,7 @@ mob_db: (
 	MoveSpeed: 350
 	AttackDelay: 1848
 	AttackMotion: 500
+	DamageDelay: 810
 	DamageMotion: 576
 },
 {
@@ -22495,6 +22889,7 @@ mob_db: (
 	MoveSpeed: 350
 	AttackDelay: 1768
 	AttackMotion: 500
+	DamageDelay: 450
 	DamageMotion: 192
 },
 {
@@ -22534,6 +22929,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1500
 	AttackMotion: 500
+	DamageDelay: 1080
 	DamageMotion: 1000
 },
 {
@@ -22574,6 +22970,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 800
 	AttackMotion: 792
+	DamageDelay: 1980
 	DamageMotion: 384
 },
 {
@@ -22614,6 +23011,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1790
 	AttackMotion: 1440
+	DamageDelay: 843
 	DamageMotion: 540
 },
 {
@@ -22653,6 +23051,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 1744
 	AttackMotion: 1344
+	DamageDelay: 900
 	DamageMotion: 600
 },
 {
@@ -22694,6 +23093,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1152
 	AttackMotion: 500
+	DamageDelay: 720
 	DamageMotion: 240
 },
 {
@@ -22736,6 +23136,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 816
 	AttackMotion: 500
+	DamageDelay: 540
 	DamageMotion: 240
 },
 {
@@ -22777,6 +23178,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 768
 	AttackMotion: 500
+	DamageDelay: 450
 	DamageMotion: 384
 },
 {
@@ -22816,6 +23218,7 @@ mob_db: (
 	MoveSpeed: 190
 	AttackDelay: 900
 	AttackMotion: 500
+	DamageDelay: 618
 	DamageMotion: 864
 },
 {
@@ -22855,6 +23258,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 528
 	AttackMotion: 500
+	DamageDelay: 315
 	DamageMotion: 240
 },
 {
@@ -22896,6 +23300,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 672
 	AttackMotion: 500
+	DamageDelay: 630
 	DamageMotion: 192
 },
 {
@@ -22936,6 +23341,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1156
 	AttackMotion: 456
+	DamageDelay: 270
 	DamageMotion: 384
 },
 // Umbala
@@ -22981,6 +23387,7 @@ mob_db: (
 	MoveSpeed: 135
 	AttackDelay: 874
 	AttackMotion: 1344
+	DamageDelay: 1260
 	DamageMotion: 576
 	MvpExp: 16547
 	MvpDrops: {
@@ -23036,6 +23443,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 950
 	AttackMotion: 2520
+	DamageDelay: 270
 	DamageMotion: 576
 	Drops: {
 		Tough_Vines: 5335
@@ -23084,6 +23492,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1247
 	AttackMotion: 768
+	DamageDelay: 225
 	DamageMotion: 576
 	Drops: {
 		Solid_Peeling: 6500
@@ -23131,6 +23540,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 2413
 	AttackMotion: 1248
+	DamageDelay: 90
 	DamageMotion: 768
 	Drops: {
 		Solid_Twig: 5000
@@ -23171,6 +23581,7 @@ mob_db: (
 	MoveSpeed: 0
 	AttackDelay: 0
 	AttackMotion: 0
+	DamageDelay: 0
 	DamageMotion: 0
 },*/
 {
@@ -23210,6 +23621,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1543
 	AttackMotion: 1632
+	DamageDelay: 360
 	DamageMotion: 480
 	Drops: {
 		Heart_Of_Tree: 4000
@@ -23259,6 +23671,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 857
 	AttackMotion: 1056
+	DamageDelay: 393
 	DamageMotion: 576
 	Drops: {
 		Air_Rifle: 4500
@@ -23308,6 +23721,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 912
 	AttackMotion: 1344
+	DamageDelay: 393
 	DamageMotion: 480
 	Drops: {
 		Meat: 4500
@@ -23353,6 +23767,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 864
 	AttackMotion: 864
+	DamageDelay: 270
 	DamageMotion: 672
 	Drops: {
 		Germinating_Sprout: 5500
@@ -23394,6 +23809,7 @@ mob_db: (
 	MoveSpeed: 0
 	AttackDelay: 0
 	AttackMotion: 0
+	DamageDelay: 0
 	DamageMotion: 0
 },*/
 {
@@ -23493,6 +23909,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 917
 	AttackMotion: 1584
+	DamageDelay: 450
 	DamageMotion: 576
 	Drops: {
 		Hanging_Doll: 1800
@@ -23541,6 +23958,7 @@ mob_db: (
 	MoveSpeed: 155
 	AttackDelay: 847
 	AttackMotion: 1152
+	DamageDelay: 360
 	DamageMotion: 480
 	Drops: {
 		Dullahans_Helm: 3200
@@ -23589,6 +24007,7 @@ mob_db: (
 	MoveSpeed: 125
 	AttackDelay: 747
 	AttackMotion: 1632
+	DamageDelay: 1530
 	DamageMotion: 576
 	Drops: {
 		Black_Kitty_Doll: 800
@@ -23638,6 +24057,7 @@ mob_db: (
 	MoveSpeed: 147
 	AttackDelay: 516
 	AttackMotion: 768
+	DamageDelay: 337
 	DamageMotion: 384
 	Drops: {
 		Red_Scarf: 4850
@@ -23687,6 +24107,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 914
 	AttackMotion: 1344
+	DamageDelay: 450
 	DamageMotion: 384
 	Drops: {
 		Old_Manteau: 4171
@@ -23736,6 +24157,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 912
 	AttackMotion: 1248
+	DamageDelay: 393
 	DamageMotion: 576
 	Drops: {
 		Piece_Of_Black_Cloth: 3200
@@ -23783,6 +24205,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 890
 	AttackMotion: 960
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Pumpkin_Bucket: 3200
@@ -23833,6 +24256,7 @@ mob_db: (
 	MoveSpeed: 155
 	AttackDelay: 741
 	AttackMotion: 1536
+	DamageDelay: 506
 	DamageMotion: 480
 	Drops: {
 		Broken_Needle: 4365
@@ -23880,6 +24304,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 854
 	AttackMotion: 2016
+	DamageDelay: 675
 	DamageMotion: 480
 	MvpExp: 43632
 	MvpDrops: {
@@ -23937,6 +24362,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 890
 	AttackMotion: 1320
+	DamageDelay: 1237
 	DamageMotion: 720
 	Drops: {
 		Brigan: 3880
@@ -23985,6 +24411,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1257
 	AttackMotion: 528
+	DamageDelay: 990
 	DamageMotion: 432
 	Drops: {
 		Fan: 4171
@@ -24030,6 +24457,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 600
 	AttackMotion: 840
+	DamageDelay: 450
 	DamageMotion: 504
 	Drops: {
 		Dragon_Fang: 4365
@@ -24078,6 +24506,7 @@ mob_db: (
 	MoveSpeed: 450
 	AttackDelay: 879
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 576
 	Drops: {
 		Milk_Bottle: 1500
@@ -24123,6 +24552,7 @@ mob_db: (
 	MoveSpeed: 445
 	AttackDelay: 106
 	AttackMotion: 1056
+	DamageDelay: 585
 	DamageMotion: 576
 	Drops: {
 		Dried_Sand: 4365
@@ -24171,6 +24601,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1120
 	AttackMotion: 576
+	DamageDelay: 315
 	DamageMotion: 420
 	Drops: {
 		Tiger_Skin_Panties: 4500
@@ -24220,6 +24651,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 576
 	AttackMotion: 960
+	DamageDelay: 900
 	DamageMotion: 480
 	Drops: {
 		Long_Hair: 5500
@@ -24271,6 +24703,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 1728
 	AttackMotion: 816
+	DamageDelay: 225
 	DamageMotion: 1188
 	Drops: {
 		Cyfar: 4850
@@ -24316,6 +24749,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 1152
 	AttackMotion: 672
+	DamageDelay: 405
 	DamageMotion: 672
 	Drops: {
 		Rice_Ball: 5500
@@ -24358,6 +24792,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 520
 	AttackMotion: 2304
+	DamageDelay: 2160
 	DamageMotion: 480
 },
 {
@@ -24399,6 +24834,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 1772
 	AttackMotion: 120
+	DamageDelay: 270
 	DamageMotion: 384
 },
 {
@@ -24437,6 +24873,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 1084
 	AttackMotion: 2304
+	DamageDelay: 450
 	DamageMotion: 576
 },
 {
@@ -24476,6 +24913,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 318
 	AttackMotion: 528
+	DamageDelay: 225
 	DamageMotion: 420
 },
 {
@@ -24517,6 +24955,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1504
 	AttackMotion: 840
+	DamageDelay: 270
 	DamageMotion: 900
 },
 {
@@ -24557,6 +24996,7 @@ mob_db: (
 	MoveSpeed: 145
 	AttackDelay: 472
 	AttackMotion: 576
+	DamageDelay: 450
 	DamageMotion: 288
 },
 {
@@ -24594,6 +25034,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1072
 	AttackMotion: 672
+	DamageDelay: 360
 	DamageMotion: 384
 },
 {
@@ -24630,6 +25071,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1092
 	AttackMotion: 792
+	DamageDelay: 405
 	DamageMotion: 480
 },
 {
@@ -24674,6 +25116,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 588
 	AttackMotion: 816
+	DamageDelay: 1530
 	DamageMotion: 420
 },
 {
@@ -24717,6 +25160,7 @@ mob_db: (
 	MoveSpeed: 145
 	AttackDelay: 1290
 	AttackMotion: 1140
+	DamageDelay: 731
 	DamageMotion: 576
 },
 {
@@ -24755,6 +25199,7 @@ mob_db: (
 	MoveSpeed: 190
 	AttackDelay: 480
 	AttackMotion: 840
+	DamageDelay: 585
 	DamageMotion: 432
 },
 {
@@ -24794,6 +25239,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1260
 	AttackMotion: 960
+	DamageDelay: 450
 	DamageMotion: 336
 },
 {
@@ -24834,6 +25280,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1612
 	AttackMotion: 622
+	DamageDelay: 540
 	DamageMotion: 583
 },
 {
@@ -24875,6 +25322,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1120
 	AttackMotion: 620
+	DamageDelay: 360
 	DamageMotion: 240
 },
 {
@@ -24914,6 +25362,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1320
 	AttackMotion: 620
+	DamageDelay: 360
 	DamageMotion: 240
 },
 {
@@ -24953,6 +25402,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1624
 	AttackMotion: 624
+	DamageDelay: 360
 	DamageMotion: 240
 },
 {
@@ -24992,6 +25442,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1624
 	AttackMotion: 624
+	DamageDelay: 360
 	DamageMotion: 240
 },
 {
@@ -25031,6 +25482,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 3074
 	AttackMotion: 1874
+	DamageDelay: 360
 	DamageMotion: 480
 },
 {
@@ -25072,6 +25524,7 @@ mob_db: (
 	MoveSpeed: 120
 	AttackDelay: 1120
 	AttackMotion: 620
+	DamageDelay: 1170
 	DamageMotion: 240
 },
 {
@@ -25108,6 +25561,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1608
 	AttackMotion: 816
+	DamageDelay: 945
 	DamageMotion: 396
 },
 {
@@ -25143,6 +25597,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1152
 	AttackMotion: 1152
+	DamageDelay: 765
 	DamageMotion: 384
 },
 {
@@ -25225,6 +25680,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 2012
 	AttackMotion: 1728
+	DamageDelay: 540
 	DamageMotion: 672
 },
 {
@@ -25260,6 +25716,7 @@ mob_db: (
 	MoveSpeed: 155
 	AttackDelay: 1638
 	AttackMotion: 2016
+	DamageDelay: 405
 	DamageMotion: 576
 },
 {
@@ -25299,6 +25756,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1028
 	AttackMotion: 528
+	DamageDelay: 225
 	DamageMotion: 360
 },
 {
@@ -25338,6 +25796,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1528
 	AttackMotion: 528
+	DamageDelay: 225
 	DamageMotion: 360
 },
 {
@@ -25377,6 +25836,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1228
 	AttackMotion: 528
+	DamageDelay: 225
 	DamageMotion: 360
 },
 {
@@ -25418,6 +25878,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1028
 	AttackMotion: 528
+	DamageDelay: 225
 	DamageMotion: 360
 },
 {
@@ -25457,6 +25918,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 2190
 	AttackMotion: 2040
+	DamageDelay: 675
 	DamageMotion: 336
 },
 {
@@ -25495,6 +25957,7 @@ mob_db: (
 	MoveSpeed: 410
 	AttackDelay: 400
 	AttackMotion: 672
+	DamageDelay: 630
 	DamageMotion: 480
 },
 {
@@ -25531,6 +25994,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1956
 	AttackMotion: 756
+	DamageDelay: 438
 	DamageMotion: 528
 },
 {
@@ -25569,6 +26033,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1938
 	AttackMotion: 2112
+	DamageDelay: 1980
 	DamageMotion: 768
 },
 {
@@ -25610,6 +26075,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1576
 	AttackMotion: 576
+	DamageDelay: 315
 	DamageMotion: 384
 },
 {
@@ -25650,6 +26116,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1216
 	AttackMotion: 816
+	DamageDelay: 765
 	DamageMotion: 432
 },
 {
@@ -25685,6 +26152,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 864
 	AttackMotion: 864
+	DamageDelay: 270
 	DamageMotion: 672
 },
 {
@@ -25721,6 +26189,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 1148
 	AttackMotion: 1728
+	DamageDelay: 585
 	DamageMotion: 864
 },
 {
@@ -25758,6 +26227,7 @@ mob_db: (
 	MoveSpeed: 155
 	AttackDelay: 2416
 	AttackMotion: 2016
+	DamageDelay: 945
 	DamageMotion: 432
 },
 {
@@ -25797,6 +26267,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1672
 	AttackMotion: 720
+	DamageDelay: 630
 	DamageMotion: 288
 },
 {
@@ -25837,6 +26308,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1564
 	AttackMotion: 864
+	DamageDelay: 360
 	DamageMotion: 576
 },
 {
@@ -25878,6 +26350,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1003
 	AttackMotion: 1152
+	DamageDelay: 2160
 	DamageMotion: 336
 },
 {
@@ -25914,6 +26387,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1576
 	AttackMotion: 576
+	DamageDelay: 540
 	DamageMotion: 420
 },
 {
@@ -25953,6 +26427,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 2276
 	AttackMotion: 576
+	DamageDelay: 202
 	DamageMotion: 432
 },
 {
@@ -25993,6 +26468,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1439
 	AttackMotion: 1920
+	DamageDelay: 585
 	DamageMotion: 672
 },
 {
@@ -26036,6 +26512,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 637
 	AttackMotion: 1008
+	DamageDelay: 540
 	DamageMotion: 360
 },
 {
@@ -26073,6 +26550,7 @@ mob_db: (
 	MoveSpeed: 140
 	AttackDelay: 512
 	AttackMotion: 756
+	DamageDelay: 506
 	DamageMotion: 360
 },
 {
@@ -26114,6 +26592,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 1816
 	AttackMotion: 576
+	DamageDelay: 765
 	DamageMotion: 240
 },
 {
@@ -26156,6 +26635,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1792
 	AttackMotion: 792
+	DamageDelay: 540
 	DamageMotion: 336
 },
 {
@@ -26199,6 +26679,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1072
 	AttackMotion: 672
+	DamageDelay: 292
 	DamageMotion: 672
 },
 {
@@ -26240,6 +26721,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 828
 	AttackMotion: 528
+	DamageDelay: 270
 	DamageMotion: 192
 },
 {
@@ -26279,6 +26761,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1000
 	AttackMotion: 500
+	DamageDelay: 607
 	DamageMotion: 1000
 },
 {
@@ -26315,6 +26798,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1680
 	AttackMotion: 480
+	DamageDelay: 270
 	DamageMotion: 384
 },
 {
@@ -26351,6 +26835,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1372
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 },
 {
@@ -26390,6 +26875,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1552
 	AttackMotion: 1152
+	DamageDelay: 675
 	DamageMotion: 336
 },
 {
@@ -26429,6 +26915,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1372
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 432
 },
 {
@@ -26464,6 +26951,7 @@ mob_db: (
 	MoveSpeed: 1000
 	AttackDelay: 1432
 	AttackMotion: 432
+	DamageDelay: 168
 	DamageMotion: 576
 },
 {
@@ -26507,6 +26995,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1220
 	AttackMotion: 1080
+	DamageDelay: 315
 	DamageMotion: 648
 },
 {
@@ -26544,6 +27033,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1172
 	AttackMotion: 672
+	DamageDelay: 495
 	DamageMotion: 420
 },
 {
@@ -26583,6 +27073,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1888
 	AttackMotion: 1152
+	DamageDelay: 517
 	DamageMotion: 828
 },
 {
@@ -26618,6 +27109,7 @@ mob_db: (
 	MoveSpeed: 1000
 	AttackDelay: 800
 	AttackMotion: 432
+	DamageDelay: 315
 	DamageMotion: 600
 },
 {
@@ -26660,6 +27152,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 850
 	AttackMotion: 600
+	DamageDelay: 393
 	DamageMotion: 336
 },
 {
@@ -26702,6 +27195,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1080
 	AttackMotion: 648
+	DamageDelay: 607
 	DamageMotion: 480
 },
 {
@@ -26745,6 +27239,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1072
 	AttackMotion: 1056
+	DamageDelay: 990
 	DamageMotion: 384
 	Drops: {
 		Petite_DiablOfs_Wing: 3000
@@ -26798,6 +27293,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1020
 	AttackMotion: 288
+	DamageDelay: 360
 	DamageMotion: 144
 	MvpExp: 29587
 	MvpDrops: {
@@ -26855,6 +27351,7 @@ mob_db: (
 	MoveSpeed: 140
 	AttackDelay: 512
 	AttackMotion: 1152
+	DamageDelay: 360
 	DamageMotion: 672
 	Drops: {
 		Sword_Accessory: 4850
@@ -26944,6 +27441,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 960
 	AttackMotion: 864
+	DamageDelay: 810
 	DamageMotion: 720
 	Drops: {
 		Great_Leaf: 4365
@@ -26993,6 +27491,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1152
 	AttackMotion: 1536
+	DamageDelay: 360
 	DamageMotion: 576
 	Drops: {
 		Zargon: 3500
@@ -27039,6 +27538,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1864
 	AttackMotion: 864
+	DamageDelay: 810
 	DamageMotion: 288
 	Drops: {
 		Iron: 210
@@ -27084,6 +27584,7 @@ mob_db: (
 	MoveSpeed: 1000
 	AttackDelay: 1768
 	AttackMotion: 768
+	DamageDelay: 360
 	DamageMotion: 576
 },
 {
@@ -27119,6 +27620,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 1308
 	AttackMotion: 1008
+	DamageDelay: 450
 	DamageMotion: 480
 },
 {
@@ -27155,6 +27657,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1456
 	AttackMotion: 456
+	DamageDelay: 247
 	DamageMotion: 336
 	Drops: {
 		Orange_Potion: 2000
@@ -27197,6 +27700,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1100
 	AttackMotion: 560
+	DamageDelay: 630
 	DamageMotion: 580
 	Drops: {
 		Stone: 10000
@@ -27242,6 +27746,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 1772
 	AttackMotion: 120
+	DamageDelay: 270
 	DamageMotion: 384
 	Drops: {
 		Orange_Potion: 2000
@@ -27286,6 +27791,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1452
 	AttackMotion: 483
+	DamageDelay: 506
 	DamageMotion: 528
 },
 {
@@ -27321,6 +27827,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 },
 {
@@ -27361,6 +27868,7 @@ mob_db: (
 	MoveSpeed: 140
 	AttackDelay: 512
 	AttackMotion: 1152
+	DamageDelay: 360
 	DamageMotion: 672
 },
 {
@@ -27399,6 +27907,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1020
 	AttackMotion: 720
+	DamageDelay: 562
 	DamageMotion: 384
 },
 {
@@ -27440,6 +27949,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 1732
 	AttackMotion: 1332
+	DamageDelay: 438
 	DamageMotion: 540
 },
 {
@@ -27482,6 +27992,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 2536
 	AttackMotion: 1536
+	DamageDelay: 1440
 	DamageMotion: 672
 },
 {
@@ -27523,6 +28034,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1452
 	AttackMotion: 483
+	DamageDelay: 1215
 	DamageMotion: 528
 },
 {
@@ -27564,6 +28076,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1100
 	AttackMotion: 483
+	DamageDelay: 675
 	DamageMotion: 528
 },
 {
@@ -27605,6 +28118,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1452
 	AttackMotion: 483
+	DamageDelay: 1350
 	DamageMotion: 528
 },
 {
@@ -27641,6 +28155,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1260
 	AttackMotion: 192
+	DamageDelay: 1181
 	DamageMotion: 192
 },
 {
@@ -27683,6 +28198,7 @@ mob_db: (
 	MoveSpeed: 155
 	AttackDelay: 1292
 	AttackMotion: 792
+	DamageDelay: 742
 	DamageMotion: 340
 },
 {
@@ -27726,6 +28242,7 @@ mob_db: (
 	MoveSpeed: 145
 	AttackDelay: 1024
 	AttackMotion: 768
+	DamageDelay: 5130
 	DamageMotion: 480
 },
 {
@@ -27766,6 +28283,7 @@ mob_db: (
 	MoveSpeed: 450
 	AttackDelay: 879
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 576
 },
 {
@@ -27808,6 +28326,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1120
 	AttackMotion: 620
+	DamageDelay: 360
 	DamageMotion: 240
 },
 {
@@ -27849,6 +28368,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 988
 	AttackMotion: 288
+	DamageDelay: 720
 	DamageMotion: 768
 },
 {
@@ -27887,6 +28407,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 600
 	AttackMotion: 840
+	DamageDelay: 450
 	DamageMotion: 504
 	Drops: {
 		Lucky_Candy: 500
@@ -27936,6 +28457,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 2468
 	AttackMotion: 768
+	DamageDelay: 450
 	DamageMotion: 288
 	Drops: {
 		Orange_Potion: 2000
@@ -27982,6 +28504,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1720
 	AttackMotion: 500
+	DamageDelay: 1080
 	DamageMotion: 420
 	Drops: {
 		Orange_Potion: 2000
@@ -28029,6 +28552,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 890
 	AttackMotion: 1320
+	DamageDelay: 1237
 	DamageMotion: 720
 	Drops: {
 		Orange_Potion: 2000
@@ -28071,6 +28595,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 384
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Tube: 4000
@@ -28117,6 +28642,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 648
 	AttackMotion: 480
+	DamageDelay: 281
 	DamageMotion: 360
 	Drops: {
 		Fragment_Of_Crystal: 3000
@@ -28166,6 +28692,7 @@ mob_db: (
 	MoveSpeed: 350
 	AttackDelay: 720
 	AttackMotion: 864
+	DamageDelay: 585
 	DamageMotion: 504
 	Drops: {
 		Dark_Crystal_Fragment: 3000
@@ -28211,6 +28738,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 960
 	AttackMotion: 336
+	DamageDelay: 225
 	DamageMotion: 300
 	Drops: {
 		Old_Pick: 3000
@@ -28261,6 +28789,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1152
 	AttackMotion: 528
+	DamageDelay: 225
 	DamageMotion: 360
 	Drops: {
 		Battered_Kettle: 1000
@@ -28313,6 +28842,7 @@ mob_db: (
 	MoveSpeed: 350
 	AttackDelay: 420
 	AttackMotion: 576
+	DamageDelay: 225
 	DamageMotion: 420
 	Drops: {
 		Long_Limb: 4500
@@ -28360,6 +28890,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 720
 	AttackMotion: 360
+	DamageDelay: 112
 	DamageMotion: 360
 	Drops: {
 		Jubilee: 5000
@@ -28408,6 +28939,7 @@ mob_db: (
 	MoveSpeed: 350
 	AttackDelay: 768
 	AttackMotion: 1440
+	DamageDelay: 495
 	DamageMotion: 672
 	Drops: {
 		Poisonous_Gas: 1000
@@ -28455,6 +28987,7 @@ mob_db: (
 	MoveSpeed: 350
 	AttackDelay: 768
 	AttackMotion: 1440
+	DamageDelay: 495
 	DamageMotion: 672
 	Drops: {
 		Air_Pollutant: 5000
@@ -28503,6 +29036,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 512
 	AttackMotion: 780
+	DamageDelay: 562
 	DamageMotion: 504
 	Drops: {
 		Screw: 3800
@@ -28557,6 +29091,7 @@ mob_db: (
 	MoveSpeed: 220
 	AttackDelay: 128
 	AttackMotion: 1104
+	DamageDelay: 450
 	DamageMotion: 240
 	MvpExp: 15505
 	MvpDrops: {
@@ -28613,6 +29148,7 @@ mob_db: (
 	MoveSpeed: 220
 	AttackDelay: 1152
 	AttackMotion: 528
+	DamageDelay: 225
 	DamageMotion: 360
 },
 {
@@ -28653,6 +29189,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 720
 	AttackMotion: 360
+	DamageDelay: 112
 	DamageMotion: 360
 },
 // Hellion Revenant
@@ -28697,6 +29234,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 432
 	AttackMotion: 384
+	DamageDelay: 360
 	DamageMotion: 192
 	Drops: {
 		Eye_Of_Hellion: 8000
@@ -28746,6 +29284,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 140
 	AttackMotion: 864
+	DamageDelay: 360
 	DamageMotion: 430
 	Drops: {
 		Wing_Of_Fly: 1000
@@ -28789,6 +29328,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 140
 	AttackMotion: 960
+	DamageDelay: 225
 	DamageMotion: 504
 	Drops: {
 		Moustache_Of_Mole: 5000
@@ -28835,6 +29375,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 336
 	AttackMotion: 540
+	DamageDelay: 337
 	DamageMotion: 432
 	Drops: {
 		Meat: 1000
@@ -28882,6 +29423,7 @@ mob_db: (
 	MoveSpeed: 130
 	AttackDelay: 576
 	AttackMotion: 960
+	DamageDelay: 900
 	DamageMotion: 480
 	MvpExp: 22625
 	MvpDrops: {
@@ -28938,6 +29480,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1728
 	AttackMotion: 816
+	DamageDelay: 225
 	DamageMotion: 1188
 	Drops: {
 		Cyfar: 4200
@@ -28984,6 +29527,7 @@ mob_db: (
 	MoveSpeed: 140
 	AttackDelay: 432
 	AttackMotion: 540
+	DamageDelay: 225
 	DamageMotion: 432
 	Drops: {
 		Will_Of_Darkness: 3000
@@ -29029,6 +29573,7 @@ mob_db: (
 	MoveSpeed: 190
 	AttackDelay: 336
 	AttackMotion: 840
+	DamageDelay: 281
 	DamageMotion: 360
 	Drops: {
 		Prickly_Fruit: 3000
@@ -29079,6 +29624,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Armlet_Of_Prisoner: 3000
@@ -29130,6 +29676,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Lab_Staff_Record: 2000
@@ -29180,6 +29727,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 225
 	DamageMotion: 288
 	Drops: {
 		Armlet_Of_Prisoner: 3000
@@ -29231,6 +29779,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 1152
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Lab_Staff_Record: 2000
@@ -29281,6 +29830,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Armlet_Of_Prisoner: 3000
@@ -29332,6 +29882,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1152
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Armlet_Of_Prisoner: 3000
@@ -29386,6 +29937,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Old_Violet_Box: 10
@@ -29432,6 +29984,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Old_Violet_Box: 10
@@ -29479,6 +30032,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 225
 	DamageMotion: 288
 	Drops: {
 		Old_Violet_Box: 10
@@ -29526,6 +30080,7 @@ mob_db: (
 	MoveSpeed: 125
 	AttackDelay: 1152
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Old_Violet_Box: 10
@@ -29573,6 +30128,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Old_Violet_Box: 10
@@ -29620,6 +30176,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1152
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Old_Violet_Box: 10
@@ -29667,6 +30224,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	MvpExp: 2417800
 	MvpDrops: {
@@ -29726,6 +30284,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	MvpExp: 2041700
 	MvpDrops: {
@@ -29786,6 +30345,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 225
 	DamageMotion: 288
 	MvpExp: 2001170
 	MvpDrops: {
@@ -29846,6 +30406,7 @@ mob_db: (
 	MoveSpeed: 125
 	AttackDelay: 1152
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	MvpExp: 2128500
 	MvpDrops: {
@@ -29906,6 +30467,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	MvpExp: 2046500
 	MvpDrops: {
@@ -29966,6 +30528,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1152
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	MvpExp: 2004100
 	MvpDrops: {
@@ -30023,6 +30586,7 @@ mob_db: (
 	MoveSpeed: 145
 	AttackDelay: 576
 	AttackMotion: 432
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Lab_Staff_Record: 1000
@@ -30073,6 +30637,7 @@ mob_db: (
 	MoveSpeed: 120
 	AttackDelay: 576
 	AttackMotion: 432
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Armlet_Of_Prisoner: 2000
@@ -30123,6 +30688,7 @@ mob_db: (
 	MoveSpeed: 120
 	AttackDelay: 576
 	AttackMotion: 432
+	DamageDelay: 225
 	DamageMotion: 288
 	Drops: {
 		Armlet_Of_Prisoner: 1000
@@ -30173,6 +30739,7 @@ mob_db: (
 	MoveSpeed: 130
 	AttackDelay: 576
 	AttackMotion: 432
+	DamageDelay: 315
 	DamageMotion: 288
 	Drops: {
 		Armlet_Of_Prisoner: 500
@@ -30223,6 +30790,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 576
 	AttackMotion: 432
+	DamageDelay: 315
 	DamageMotion: 288
 	Drops: {
 		Lab_Staff_Record: 2000
@@ -30273,6 +30841,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 576
 	AttackMotion: 432
+	DamageDelay: 315
 	DamageMotion: 288
 	Drops: {
 		Mementos: 1000
@@ -30328,6 +30897,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1008
 	AttackMotion: 864
+	DamageDelay: 270
 	DamageMotion: 288
 	MvpExp: 129380
 	MvpDrops: {
@@ -30384,6 +30954,7 @@ mob_db: (
 	MoveSpeed: 120
 	AttackDelay: 1008
 	AttackMotion: 864
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Gift_Box: 10
@@ -30427,6 +30998,7 @@ mob_db: (
 	MoveSpeed: 120
 	AttackDelay: 1008
 	AttackMotion: 864
+	DamageDelay: 225
 	DamageMotion: 288
 	Drops: {
 		Gift_Box: 10
@@ -30470,6 +31042,7 @@ mob_db: (
 	MoveSpeed: 130
 	AttackDelay: 1008
 	AttackMotion: 864
+	DamageDelay: 315
 	DamageMotion: 288
 	Drops: {
 		Gift_Box: 10
@@ -30513,6 +31086,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1008
 	AttackMotion: 864
+	DamageDelay: 315
 	DamageMotion: 288
 	Drops: {
 		Gift_Box: 10
@@ -30556,6 +31130,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1008
 	AttackMotion: 864
+	DamageDelay: 315
 	DamageMotion: 288
 	Drops: {
 		Gift_Box: 10
@@ -30595,6 +31170,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1536
 	AttackMotion: 960
+	DamageDelay: 450
 	DamageMotion: 480
 	Drops: {
 		Large_Jellopy: 5000
@@ -30635,6 +31211,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1536
 	AttackMotion: 960
+	DamageDelay: 450
 	DamageMotion: 480
 	Drops: {
 		Large_Jellopy: 5000
@@ -30676,6 +31253,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1536
 	AttackMotion: 960
+	DamageDelay: 450
 	DamageMotion: 480
 	Drops: {
 		Large_Jellopy: 5000
@@ -30716,6 +31294,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1536
 	AttackMotion: 960
+	DamageDelay: 450
 	DamageMotion: 480
 	Drops: {
 		Large_Jellopy: 5000
@@ -30762,6 +31341,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 580
 	AttackMotion: 288
+	DamageDelay: 180
 	DamageMotion: 360
 	Drops: {
 		Screw: 5000
@@ -30810,6 +31390,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 576
 	AttackMotion: 720
+	DamageDelay: 315
 	DamageMotion: 432
 	Drops: {
 		Dimik_Card: 1
@@ -30852,6 +31433,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 576
 	AttackMotion: 720
+	DamageDelay: 315
 	DamageMotion: 432
 	Drops: {
 		Old_Steel_Plate: 2000
@@ -30901,6 +31483,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 576
 	AttackMotion: 720
+	DamageDelay: 315
 	DamageMotion: 432
 	Drops: {
 		Old_Steel_Plate: 2000
@@ -30950,6 +31533,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 576
 	AttackMotion: 720
+	DamageDelay: 315
 	DamageMotion: 432
 	Drops: {
 		Old_Steel_Plate: 2000
@@ -30999,6 +31583,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 576
 	AttackMotion: 720
+	DamageDelay: 315
 	DamageMotion: 432
 	Drops: {
 		Old_Steel_Plate: 2000
@@ -31046,6 +31631,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1368
 	AttackMotion: 1344
+	DamageDelay: 450
 	DamageMotion: 432
 	Drops: {
 		Stone: 2000
@@ -31089,6 +31675,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 504
 	AttackMotion: 1020
+	DamageDelay: 562
 	DamageMotion: 360
 	Drops: {
 		Venatu_Card: 1
@@ -31131,6 +31718,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 504
 	AttackMotion: 1020
+	DamageDelay: 562
 	DamageMotion: 360
 	Drops: {
 		Screw: 2000
@@ -31180,6 +31768,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 504
 	AttackMotion: 1020
+	DamageDelay: 562
 	DamageMotion: 360
 	Drops: {
 		Screw: 2000
@@ -31229,6 +31818,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 504
 	AttackMotion: 1020
+	DamageDelay: 562
 	DamageMotion: 360
 	Drops: {
 		Screw: 2000
@@ -31278,6 +31868,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 504
 	AttackMotion: 1020
+	DamageDelay: 562
 	DamageMotion: 360
 	Drops: {
 		Screw: 2000
@@ -31327,6 +31918,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 504
 	AttackMotion: 480
+	DamageDelay: 270
 	DamageMotion: 360
 	Drops: {
 		Harpys_Feather: 4000
@@ -31375,6 +31967,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1872
 	AttackMotion: 360
+	DamageDelay: 225
 	DamageMotion: 864
 	Drops: {
 		Skull: 3000
@@ -31425,6 +32018,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1536
 	AttackMotion: 1056
+	DamageDelay: 315
 	DamageMotion: 1152
 	Drops: {
 		Empty_Bottle: 5000
@@ -31474,6 +32068,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1536
 	AttackMotion: 960
+	DamageDelay: 450
 	DamageMotion: 480
 },
 {
@@ -31513,6 +32108,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 1080
 	AttackMotion: 288
+	DamageDelay: 180
 	DamageMotion: 360
 },
 {
@@ -31556,6 +32152,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 504
 	AttackMotion: 912
+	DamageDelay: 495
 	DamageMotion: 432
 	MvpExp: 100000
 	MvpDrops: {
@@ -31611,6 +32208,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 672
 	AttackMotion: 864
+	DamageDelay: 472
 	DamageMotion: 288
 	Drops: {
 		Large_Jellopy: 1000
@@ -31657,6 +32255,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 720
 	AttackMotion: 528
+	DamageDelay: 315
 	DamageMotion: 432
 	Drops: {
 		Leaflet_Of_Aloe: 1500
@@ -31704,6 +32303,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 576
 	AttackMotion: 432
+	DamageDelay: 360
 	DamageMotion: 360
 	MvpExp: 32497
 	MvpDrops: {
@@ -31764,6 +32364,7 @@ mob_db: (
 	MoveSpeed: 130
 	AttackDelay: 576
 	AttackMotion: 960
+	DamageDelay: 900
 	DamageMotion: 480
 },
 {
@@ -31802,6 +32403,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 1120
 	AttackMotion: 552
+	DamageDelay: 2340
 	DamageMotion: 511
 	Drops: {
 		Hometown_Gift: 100
@@ -31847,6 +32449,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1152
 	AttackMotion: 1536
+	DamageDelay: 360
 	DamageMotion: 576
 	Drops: {
 		Leaflet_Of_Aloe: 1
@@ -31896,6 +32499,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 140
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 504
 	Drops: {
 		Raccoon_Leaf: 500
@@ -31945,6 +32549,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 608
 	AttackMotion: 1440
+	DamageDelay: 1215
 	DamageMotion: 576
 	Drops: {
 		Scell: 100
@@ -31992,6 +32597,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 608
 	AttackMotion: 1440
+	DamageDelay: 1215
 	DamageMotion: 576
 	Drops: {
 		Scell: 100
@@ -32039,6 +32645,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 608
 	AttackMotion: 1440
+	DamageDelay: 1215
 	DamageMotion: 576
 	Drops: {
 		Scell: 100
@@ -32086,6 +32693,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 608
 	AttackMotion: 1440
+	DamageDelay: 1215
 	DamageMotion: 576
 	Drops: {
 		Scell: 100
@@ -32133,6 +32741,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 608
 	AttackMotion: 1440
+	DamageDelay: 1215
 	DamageMotion: 576
 	Drops: {
 		Scell: 100
@@ -32183,6 +32792,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 176
 	AttackMotion: 912
+	DamageDelay: 495
 	DamageMotion: 300
 	Drops: {
 		Worn_Out_Page: 4000
@@ -32232,6 +32842,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 168
 	AttackMotion: 480
+	DamageDelay: 225
 	DamageMotion: 360
 	Drops: {
 		Old_Blue_Box: 30
@@ -32285,6 +32896,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 432
 	AttackMotion: 480
+	DamageDelay: 281
 	DamageMotion: 360
 	Drops: {
 		Blue_Feather: 500
@@ -32338,6 +32950,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 432
 	AttackMotion: 420
+	DamageDelay: 225
 	DamageMotion: 360
 	Drops: {
 		Red_Feather: 200
@@ -32390,6 +33003,7 @@ mob_db: (
 	MoveSpeed: 120
 	AttackDelay: 360
 	AttackMotion: 480
+	DamageDelay: 225
 	DamageMotion: 360
 	Drops: {
 		Red_Feather: 400
@@ -32443,6 +33057,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 576
 	AttackMotion: 420
+	DamageDelay: 360
 	DamageMotion: 360
 	Drops: {
 		Blue_Feather: 200
@@ -32497,6 +33112,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 432
 	AttackMotion: 288
+	DamageDelay: 180
 	DamageMotion: 420
 	Drops: {
 		Brigan: 1000
@@ -32550,6 +33166,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 160
 	AttackMotion: 528
+	DamageDelay: 360
 	DamageMotion: 360
 	Drops: {
 		Brigan: 1000
@@ -32603,6 +33220,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 160
 	AttackMotion: 480
+	DamageDelay: 281
 	DamageMotion: 360
 	Drops: {
 		Brigan: 1000
@@ -32656,6 +33274,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 160
 	AttackMotion: 672
+	DamageDelay: 450
 	DamageMotion: 480
 	Drops: {
 		Brigan: 1000
@@ -32709,6 +33328,7 @@ mob_db: (
 	MoveSpeed: 120
 	AttackDelay: 115
 	AttackMotion: 816
+	DamageDelay: 630
 	DamageMotion: 504
 	MvpExp: 1833000
 	MvpDrops: {
@@ -32768,6 +33388,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 115
 	AttackMotion: 288
+	DamageDelay: 180
 	DamageMotion: 420
 	Drops: {
 		Brigan: 1000
@@ -32816,6 +33437,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 160
 	AttackMotion: 528
+	DamageDelay: 360
 	DamageMotion: 360
 	Drops: {
 		Brigan: 1000
@@ -32864,6 +33486,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 160
 	AttackMotion: 480
+	DamageDelay: 281
 	DamageMotion: 360
 	Drops: {
 		Brigan: 1000
@@ -32912,6 +33535,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 160
 	AttackMotion: 672
+	DamageDelay: 450
 	DamageMotion: 480
 	Drops: {
 		Brigan: 1000
@@ -32956,6 +33580,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 168
 	AttackMotion: 1008
+	DamageDelay: 495
 	DamageMotion: 300
 	Drops: {
 		Orange: 5100
@@ -33005,6 +33630,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 108
 	AttackMotion: 576
+	DamageDelay: 360
 	DamageMotion: 432
 	Drops: {
 		Strawberry: 2200
@@ -33054,6 +33680,7 @@ mob_db: (
 	MoveSpeed: 110
 	AttackDelay: 151
 	AttackMotion: 288
+	DamageDelay: 225
 	DamageMotion: 360
 	Drops: {
 		Green_Herb: 3000
@@ -33099,6 +33726,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 168
 	AttackMotion: 768
+	DamageDelay: 495
 	DamageMotion: 360
 	Drops: {
 		Blue_Potion: 150
@@ -33148,6 +33776,7 @@ mob_db: (
 	MoveSpeed: 120
 	AttackDelay: 108
 	AttackMotion: 576
+	DamageDelay: 360
 	DamageMotion: 432
 	Drops: {
 		Delicious_Fish: 5100
@@ -33196,6 +33825,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 252
 	AttackMotion: 816
+	DamageDelay: 495
 	DamageMotion: 480
 	Drops: {
 		Yellow_Herb: 2000
@@ -33246,6 +33876,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 432
 	AttackMotion: 936
+	DamageDelay: 225
 	DamageMotion: 360
 	MvpExp: 145925
 	MvpDrops: {
@@ -33306,6 +33937,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 140
 	AttackMotion: 672
+	DamageDelay: 360
 	DamageMotion: 432
 	Drops: {
 		Dragons_Skin: 4000
@@ -33347,6 +33979,7 @@ mob_db: (
 	MoveSpeed: 1000
 	AttackDelay: 24
 	AttackMotion: 0
+	DamageDelay: 22
 	DamageMotion: 0
 	Drops: {
 		Elunium: 5
@@ -33393,6 +34026,7 @@ mob_db: (
 	MoveSpeed: 240
 	AttackDelay: 1180
 	AttackMotion: 480
+	DamageDelay: 180
 	DamageMotion: 648
 	Drops: {
 		Pumpkin_Bucket: 1000
@@ -33441,6 +34075,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 1008
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 },
 {
@@ -33476,6 +34111,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1536
 	AttackMotion: 960
+	DamageDelay: 450
 	DamageMotion: 480
 },
 {
@@ -33512,6 +34148,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 },
 {
@@ -33548,6 +34185,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1456
 	AttackMotion: 456
+	DamageDelay: 247
 	DamageMotion: 336
 },
 {
@@ -33584,6 +34222,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1624
 	AttackMotion: 624
+	DamageDelay: 292
 	DamageMotion: 576
 },
 {
@@ -33621,6 +34260,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1600
 	AttackMotion: 900
+	DamageDelay: 236
 	DamageMotion: 240
 },
 {
@@ -33658,6 +34298,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 868
 	AttackMotion: 480
+	DamageDelay: 540
 	DamageMotion: 120
 },
 {
@@ -33695,6 +34336,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 980
 	AttackMotion: 600
+	DamageDelay: 270
 	DamageMotion: 384
 },
 {
@@ -33739,6 +34381,7 @@ mob_db: (
 	MoveSpeed: 190
 	AttackDelay: 480
 	AttackMotion: 480
+	DamageDelay: 180
 	DamageMotion: 288
 	Drops: {
 		Warrior_Symbol: 10000
@@ -33825,6 +34468,7 @@ mob_db: (
 	MoveSpeed: 140
 	AttackDelay: 1152
 	AttackMotion: 576
+	DamageDelay: 360
 	DamageMotion: 432
 },
 {
@@ -33868,6 +34512,7 @@ mob_db: (
 	MoveSpeed: 130
 	AttackDelay: 1152
 	AttackMotion: 576
+	DamageDelay: 360
 	DamageMotion: 432
 	MvpExp: 1178100
 	MvpDrops: {
@@ -33924,6 +34569,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1080
 	AttackMotion: 480
+	DamageDelay: 225
 	DamageMotion: 504
 	Drops: {
 		Burnt_Parts: 2000
@@ -33974,6 +34620,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1296
 	AttackMotion: 432
+	DamageDelay: 270
 	DamageMotion: 360
 	Drops: {
 		Burnt_Parts: 2000
@@ -34020,6 +34667,7 @@ mob_db: (
 	MoveSpeed: 220
 	AttackDelay: 1440
 	AttackMotion: 576
+	DamageDelay: 315
 	DamageMotion: 600
 	Drops: {
 		Brigan: 4000
@@ -34069,6 +34717,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 720
 	AttackMotion: 360
+	DamageDelay: 337
 	DamageMotion: 360
 	Drops: {
 		Burnt_Parts: 100
@@ -34116,6 +34765,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1080
 	AttackMotion: 480
+	DamageDelay: 225
 	DamageMotion: 504
 	Drops: {
 		Sturdy_Iron_Piece: 500
@@ -34159,6 +34809,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1296
 	AttackMotion: 432
+	DamageDelay: 270
 	DamageMotion: 360
 	Drops: {
 		Sturdy_Iron_Piece: 500
@@ -34201,6 +34852,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1248
 	AttackMotion: 1248
+	DamageDelay: 315
 	DamageMotion: 240
 },
 {
@@ -34241,6 +34893,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1078
 	AttackMotion: 768
+	DamageDelay: 540
 	DamageMotion: 384
 },
 {
@@ -34280,6 +34933,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1248
 	AttackMotion: 1248
+	DamageDelay: 405
 	DamageMotion: 432
 },
 {
@@ -34319,6 +34973,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 964
 	AttackMotion: 864
+	DamageDelay: 787
 	DamageMotion: 288
 },
 {
@@ -34357,6 +35012,7 @@ mob_db: (
 	MoveSpeed: 110
 	AttackDelay: 720
 	AttackMotion: 360
+	DamageDelay: 337
 	DamageMotion: 360
 	Drops: {
 		Sturdy_Iron_Piece: 500
@@ -34399,6 +35055,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1440
 	AttackMotion: 576
+	DamageDelay: 315
 	DamageMotion: 600
 	Drops: {
 		Sturdy_Iron_Piece: 500
@@ -34442,6 +35099,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1576
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 576
 },
 {
@@ -34481,6 +35139,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1576
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 576
 },
 {
@@ -34521,6 +35180,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 1720
 	AttackMotion: 1320
+	DamageDelay: 1012
 	DamageMotion: 360
 },
 {
@@ -34555,6 +35215,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 1
 	AttackMotion: 1
+	DamageDelay: 1080
 	DamageMotion: 1
 },
 // Odin monsters
@@ -34599,6 +35260,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 576
 	AttackMotion: 576
+	DamageDelay: 472
 	DamageMotion: 480
 	MvpExp: 1427450
 	MvpDrops: {
@@ -34655,6 +35317,7 @@ mob_db: (
 	MoveSpeed: 190
 	AttackDelay: 720
 	AttackMotion: 384
+	DamageDelay: 337
 	DamageMotion: 480
 	Drops: {
 		Rune_Of_Darkness: 3500
@@ -34706,6 +35369,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 480
 	AttackMotion: 576
+	DamageDelay: 180
 	DamageMotion: 432
 	Drops: {
 		Rune_Of_Darkness: 3500
@@ -34758,6 +35422,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 672
 	AttackMotion: 780
+	DamageDelay: 337
 	DamageMotion: 480
 	Drops: {
 		Rune_Of_Darkness: 6000
@@ -34811,6 +35476,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 672
 	AttackMotion: 780
+	DamageDelay: 337
 	DamageMotion: 480
 	Drops: {
 		Rune_Of_Darkness: 6000
@@ -34863,6 +35529,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 140
 	AttackMotion: 672
+	DamageDelay: 360
 	DamageMotion: 432
 },
 {
@@ -34902,6 +35569,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 168
 	AttackMotion: 1008
+	DamageDelay: 495
 	DamageMotion: 300
 },
 {
@@ -34941,6 +35609,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 108
 	AttackMotion: 576
+	DamageDelay: 360
 	DamageMotion: 432
 },
 {
@@ -34980,6 +35649,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 168
 	AttackMotion: 768
+	DamageDelay: 495
 	DamageMotion: 360
 },
 {
@@ -35019,6 +35689,7 @@ mob_db: (
 	MoveSpeed: 120
 	AttackDelay: 108
 	AttackMotion: 576
+	DamageDelay: 360
 	DamageMotion: 432
 },
 {
@@ -35059,6 +35730,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 720
 	AttackMotion: 384
+	DamageDelay: 337
 	DamageMotion: 480
 	Drops: {
 		Rune_Of_Darkness: 500
@@ -35102,6 +35774,7 @@ mob_db: (
 	MoveSpeed: 130
 	AttackDelay: 480
 	AttackMotion: 576
+	DamageDelay: 180
 	DamageMotion: 432
 	Drops: {
 		Rune_Of_Darkness: 500
@@ -35146,6 +35819,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 672
 	AttackMotion: 780
+	DamageDelay: 337
 	DamageMotion: 480
 	Drops: {
 		Rune_Of_Darkness: 500
@@ -35190,6 +35864,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 672
 	AttackMotion: 780
+	DamageDelay: 337
 	DamageMotion: 480
 	Drops: {
 		Rune_Of_Darkness: 500
@@ -35236,6 +35911,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 576
 	AttackMotion: 576
+	DamageDelay: 472
 	DamageMotion: 480
 	Drops: {
 		Valhalla_Flower: 500
@@ -35280,6 +35956,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 292
 	DamageMotion: 384
 	MvpDrops: {
 		Jellopy: 5000
@@ -35324,6 +36001,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 990
 	DamageMotion: 384
 	MvpDrops: {
 		Jellopy: 5000
@@ -35373,6 +36051,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1344
 	AttackMotion: 2880
+	DamageDelay: 270
 	DamageMotion: 576
 	MvpExp: 481087
 	MvpDrops: {
@@ -35428,6 +36107,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 768
 	AttackMotion: 360
+	DamageDelay: 281
 	DamageMotion: 360
 	Drops: {
 		Suspicious_Hat: 2500
@@ -35477,6 +36157,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 768
 	AttackMotion: 360
+	DamageDelay: 281
 	DamageMotion: 360
 	Drops: {
 		Suspicious_Hat: 2500
@@ -35526,6 +36207,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 768
 	AttackMotion: 360
+	DamageDelay: 281
 	DamageMotion: 360
 	Drops: {
 		White_Mask: 2500
@@ -35574,6 +36256,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 768
 	AttackMotion: 360
+	DamageDelay: 337
 	DamageMotion: 432
 	Drops: {
 		White_Mask: 2500
@@ -35623,6 +36306,7 @@ mob_db: (
 	MoveSpeed: 140
 	AttackDelay: 960
 	AttackMotion: 528
+	DamageDelay: 360
 	DamageMotion: 432
 	Drops: {
 		Prickly_Fruit_: 1000
@@ -35673,6 +36357,7 @@ mob_db: (
 	MoveSpeed: 190
 	AttackDelay: 576
 	AttackMotion: 432
+	DamageDelay: 315
 	DamageMotion: 300
 	Drops: {
 		Prickly_Fruit_: 1000
@@ -35721,6 +36406,7 @@ mob_db: (
 	MoveSpeed: 220
 	AttackDelay: 936
 	AttackMotion: 1020
+	DamageDelay: 618
 	DamageMotion: 420
 	Drops: {
 		Ice_Heart: 3000
@@ -35767,6 +36453,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 432
 	AttackMotion: 648
+	DamageDelay: 405
 	DamageMotion: 240
 	Drops: {
 		Ice_Heart: 1000
@@ -35813,6 +36500,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 861
 	AttackMotion: 660
+	DamageDelay: 562
 	DamageMotion: 144
 	Drops: {
 		Ice_Heart: 5000
@@ -35863,6 +36551,7 @@ mob_db: (
 	MoveSpeed: 190
 	AttackDelay: 576
 	AttackMotion: 370
+	DamageDelay: 281
 	DamageMotion: 270
 	Drops: {
 		Ice_Heart: 3000
@@ -35913,6 +36602,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 432
 	AttackMotion: 840
+	DamageDelay: 618
 	DamageMotion: 216
 	MvpExp: 1360025
 	MvpDrops: {
@@ -35963,6 +36653,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 672
 	AttackMotion: 648
+	DamageDelay: 472
 	DamageMotion: 360
 	Drops: {
 		Sticky_Poison: 3000
@@ -36007,6 +36698,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 864
 	AttackMotion: 576
+	DamageDelay: 472
 	DamageMotion: 336
 	Drops: {
 		Sticky_Poison: 3000
@@ -36054,6 +36746,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 412
 	AttackMotion: 840
+	DamageDelay: 562
 	DamageMotion: 300
 	Drops: {
 		Rotten_Meat: 3000
@@ -36101,6 +36794,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 864
 	AttackMotion: 624
+	DamageDelay: 450
 	DamageMotion: 360
 	Drops: {
 		Rotten_Meat: 3000
@@ -36144,6 +36838,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 936
 	AttackMotion: 792
+	DamageDelay: 742
 	DamageMotion: 432
 	Drops: {
 		Jellopy: 1000
@@ -36196,6 +36891,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 576
 	AttackMotion: 600
+	DamageDelay: 450
 	DamageMotion: 240
 	MvpExp: 147775
 	MvpDrops: {
@@ -36252,6 +36948,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 768
 	AttackMotion: 360
+	DamageDelay: 281
 	DamageMotion: 360
 	Drops: {
 		Suspicious_Hat: 1
@@ -36295,6 +36992,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 768
 	AttackMotion: 360
+	DamageDelay: 281
 	DamageMotion: 360
 	Drops: {
 		Suspicious_Hat: 1
@@ -36338,6 +37036,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 861
 	AttackMotion: 660
+	DamageDelay: 562
 	DamageMotion: 144
 	Drops: {
 		Ice_Heart: 1
@@ -36376,6 +37075,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 1344
 	AttackMotion: 0
+	DamageDelay: 1260
 	DamageMotion: 0
 	Drops: {
 		Ice_Piece: 1000
@@ -36425,6 +37125,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 512
 	AttackMotion: 528
+	DamageDelay: 405
 	DamageMotion: 240
 	Drops: {
 		Golden_Jewel_: 3000
@@ -36470,6 +37171,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 864
 	AttackMotion: 624
+	DamageDelay: 450
 	DamageMotion: 360
 },
 {
@@ -36504,6 +37206,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 96
 	AttackMotion: 96
+	DamageDelay: 0
 	DamageMotion: 96
 },
 {
@@ -36545,6 +37248,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1332
 	AttackMotion: 1332
+	DamageDelay: 877
 	DamageMotion: 672
 },
 {
@@ -36585,6 +37289,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 412
 	AttackMotion: 840
+	DamageDelay: 562
 	DamageMotion: 300
 },
 {
@@ -36628,6 +37333,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 828
 	AttackMotion: 528
+	DamageDelay: 270
 	DamageMotion: 192
 	Drops: {
 		Pole_Axe: 100
@@ -36678,6 +37384,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 768
 	AttackMotion: 432
+	DamageDelay: 337
 	DamageMotion: 360
 	Drops: {
 		Memorize_Book: 1
@@ -36726,6 +37433,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 768
 	AttackMotion: 432
+	DamageDelay: 810
 	DamageMotion: 360
 	Drops: {
 		Memorize_Book: 1
@@ -36815,6 +37523,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Evil_Mind: 300
@@ -36861,6 +37570,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Evil_Mind: 300
@@ -36908,6 +37618,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 225
 	DamageMotion: 288
 	Drops: {
 		Evil_Mind: 300
@@ -36955,6 +37666,7 @@ mob_db: (
 	MoveSpeed: 125
 	AttackDelay: 1152
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	MvpExp: 9000
 	Drops: {
@@ -37002,6 +37714,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Evil_Mind: 300
@@ -37049,6 +37762,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1152
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Evil_Mind: 300
@@ -37095,6 +37809,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Evil_Mind: 10000
@@ -37141,6 +37856,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Evil_Mind: 10000
@@ -37188,6 +37904,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 225
 	DamageMotion: 288
 	Drops: {
 		Evil_Mind: 10000
@@ -37235,6 +37952,7 @@ mob_db: (
 	MoveSpeed: 125
 	AttackDelay: 1152
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Evil_Mind: 10000
@@ -37282,6 +38000,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Evil_Mind: 10000
@@ -37329,6 +38048,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1152
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Evil_Mind: 10000
@@ -37369,6 +38089,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1576
 	AttackMotion: 576
+	DamageDelay: 540
 	DamageMotion: 420
 	Drops: {
 		Sunglasses: 100
@@ -37411,6 +38132,7 @@ mob_db: (
 	MoveSpeed: 190
 	AttackDelay: 890
 	AttackMotion: 960
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Pumpkin_Bucket: 5000
@@ -37461,6 +38183,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 972
 	AttackMotion: 672
+	DamageDelay: 360
 	DamageMotion: 432
 	Drops: {
 		Evil_Dragon_Head: 10000
@@ -37548,6 +38271,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 1320
 	AttackMotion: 0
+	DamageDelay: 607
 	DamageMotion: 300
 	Drops: {
 		Small_Rice_Dough: 10000
@@ -37592,6 +38316,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 96
 	AttackMotion: 96
+	DamageDelay: 0
 	DamageMotion: 96
 	Drops: {
 		Apple: 10000
@@ -37639,6 +38364,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 972
 	AttackMotion: 936
+	DamageDelay: 225
 	DamageMotion: 360
 	Drops: {
 		Dragon_Spirit: 10000
@@ -37689,6 +38415,7 @@ mob_db: (
 	MoveSpeed: 1000
 	AttackDelay: 1020
 	AttackMotion: 500
+	DamageDelay: 506
 	DamageMotion: 768
 	Drops: {
 		Piece_Of_Cogwheel: 7000
@@ -37733,6 +38460,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1504
 	AttackMotion: 840
+	DamageDelay: 270
 	DamageMotion: 900
 	Drops: {
 		Wooden_Block_: 2000
@@ -37772,6 +38500,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1260
 	AttackMotion: 192
+	DamageDelay: 1181
 	DamageMotion: 192
 	Drops: {
 		Wooden_Block_: 2000
@@ -37814,6 +38543,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1120
 	AttackMotion: 420
+	DamageDelay: 168
 	DamageMotion: 288
 	Drops: {
 		Wooden_Block_: 2000
@@ -37859,6 +38589,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 980
 	AttackMotion: 600
+	DamageDelay: 270
 	DamageMotion: 384
 	Drops: {
 		Wooden_Block_: 3000
@@ -37903,6 +38634,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1452
 	AttackMotion: 483
+	DamageDelay: 506
 	DamageMotion: 528
 	Drops: {
 		Wooden_Block_: 3000
@@ -37946,6 +38678,7 @@ mob_db: (
 	MoveSpeed: 450
 	AttackDelay: 879
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 576
 	Drops: {
 		Wooden_Block_: 5000
@@ -37991,6 +38724,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1120
 	AttackMotion: 620
+	DamageDelay: 360
 	DamageMotion: 240
 	Drops: {
 		Wooden_Block_: 5000
@@ -38035,6 +38769,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1576
 	AttackMotion: 576
+	DamageDelay: 315
 	DamageMotion: 384
 	Drops: {
 		Wooden_Block_: 3000
@@ -38079,6 +38814,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1260
 	AttackMotion: 192
+	DamageDelay: 1181
 	DamageMotion: 192
 	Drops: {
 		Wooden_Block_: 3000
@@ -38124,6 +38860,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1960
 	AttackMotion: 960
+	DamageDelay: 180
 	DamageMotion: 384
 	Drops: {
 		Bag_Of_Rice: 6000
@@ -38277,6 +39014,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 140
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Burning_Heart: 3000
@@ -38330,6 +39068,7 @@ mob_db: (
 	MoveSpeed: 130
 	AttackDelay: 212
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 360
 	MvpExp: 1577160
 	MvpDrops: {
@@ -38389,6 +39128,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 800
 	AttackMotion: 600
+	DamageDelay: 506
 	DamageMotion: 288
 	Drops: {
 		Burning_Heart: 3000
@@ -38442,6 +39182,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 140
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 },
 {
@@ -38485,6 +39226,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 800
 	AttackMotion: 600
+	DamageDelay: 506
 	DamageMotion: 288
 },
 {
@@ -38521,6 +39263,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1472
 	AttackMotion: 384
+	DamageDelay: 315
 	DamageMotion: 288
 	Drops: {
 		Burning_Heart: 3000
@@ -38567,6 +39310,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 824
 	AttackMotion: 432
+	DamageDelay: 337
 	DamageMotion: 360
 	Drops: {
 		Hot_Hair: 3000
@@ -38613,6 +39357,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1548
 	AttackMotion: 384
+	DamageDelay: 225
 	DamageMotion: 288
 	Drops: {
 		Great_Nature: 30
@@ -38667,6 +39412,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 800
 	AttackMotion: 600
+	DamageDelay: 337
 	DamageMotion: 360
 	Drops: {
 		Drill_Katar: 50
@@ -38715,6 +39461,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1960
 	AttackMotion: 480
+	DamageDelay: 180
 	DamageMotion: 384
 	Drops: {
 		Leaf_Of_Yggdrasil: 3000
@@ -38760,6 +39507,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1576
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 576
 	Drops: {
 		Gold_Coin_US: 2000
@@ -38801,6 +39549,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1576
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 576
 	Drops: {
 		Gold_Coin_US: 3500
@@ -38845,6 +39594,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1576
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 576
 	Drops: {
 		Gold_Coin_US: 7000
@@ -38890,6 +39640,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1384
 	AttackMotion: 768
+	DamageDelay: 450
 	DamageMotion: 336
 	Drops: {
 		Gold_Coin_US: 8000
@@ -39065,6 +39816,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 768
 	AttackMotion: 768
+	DamageDelay: 540
 	DamageMotion: 576
 },
 {
@@ -39108,6 +39860,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1072
 	AttackMotion: 672
+	DamageDelay: 180
 	DamageMotion: 384
 },
 {
@@ -39192,6 +39945,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1100
 	AttackMotion: 560
+	DamageDelay: 630
 	DamageMotion: 580
 },
 {
@@ -39235,6 +39989,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 292
 	DamageMotion: 384
 },
 {
@@ -39278,6 +40033,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 990
 	DamageMotion: 384
 },
 {
@@ -39314,6 +40070,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1960
 	AttackMotion: 960
+	DamageDelay: 450
 	DamageMotion: 384
 	Drops: {
 		Yellow_Live: 70
@@ -39410,6 +40167,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1560
 	AttackMotion: 360
+	DamageDelay: 180
 	DamageMotion: 360
 	Drops: {
 		Old_Frying_Pan: 9000
@@ -39455,6 +40213,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Garlet: 3200
@@ -39500,6 +40259,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 2208
 	AttackMotion: 1008
+	DamageDelay: 540
 	DamageMotion: 324
 	Drops: {
 		Single_Cell: 9000
@@ -39545,6 +40305,7 @@ mob_db: (
 	MoveSpeed: 1000
 	AttackDelay: 1768
 	AttackMotion: 768
+	DamageDelay: 360
 	DamageMotion: 576
 	Drops: {
 		Yellow_Live: 50
@@ -39591,6 +40352,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1864
 	AttackMotion: 864
+	DamageDelay: 472
 	DamageMotion: 1008
 	Drops: {
 		Acorn: 9000
@@ -39640,6 +40402,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1500
 	AttackMotion: 500
+	DamageDelay: 472
 	DamageMotion: 1000
 	Drops: {
 		Claw_Of_Monkey: 5335
@@ -39685,6 +40448,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1480
 	AttackMotion: 480
+	DamageDelay: 180
 	DamageMotion: 480
 	Drops: {
 		Moustache_Of_Mole: 9000
@@ -39731,6 +40495,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 1120
 	AttackMotion: 552
+	DamageDelay: 708
 	DamageMotion: 511
 	Drops: {
 		Peeps: 5000
@@ -39778,6 +40543,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 676
 	AttackMotion: 648
+	DamageDelay: 405
 	DamageMotion: 432
 	Drops: {
 		Clattering_Skull: 3000
@@ -39827,6 +40593,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1960
 	AttackMotion: 576
+	DamageDelay: 315
 	DamageMotion: 420
 	Drops: {
 		Clattering_Skull: 3000
@@ -39879,6 +40646,7 @@ mob_db: (
 	MoveSpeed: 140
 	AttackDelay: 824
 	AttackMotion: 432
+	DamageDelay: 315
 	DamageMotion: 360
 	Drops: {
 		Monsters_Feed: 5000
@@ -39931,6 +40699,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 576
 	AttackMotion: 504
+	DamageDelay: 405
 	DamageMotion: 504
 	Drops: {
 		Old_White_Cloth: 3000
@@ -39982,6 +40751,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 576
 	AttackMotion: 504
+	DamageDelay: 405
 	DamageMotion: 504
 },
 {
@@ -40022,6 +40792,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 972
 	AttackMotion: 648
+	DamageDelay: 472
 	DamageMotion: 432
 	Drops: {
 		Skull: 5000
@@ -40072,6 +40843,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1816
 	AttackMotion: 1320
+	DamageDelay: 731
 	DamageMotion: 420
 	Drops: {
 		Clattering_Skull: 3000
@@ -40126,6 +40898,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 432
 	AttackMotion: 1152
+	DamageDelay: 270
 	DamageMotion: 360
 	MvpExp: 555555
 	MvpDrops: {
@@ -40184,6 +40957,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 676
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 480
 },
 {
@@ -40227,6 +41001,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 100
 	AttackMotion: 576
+	DamageDelay: 236
 	DamageMotion: 480
 },
 {
@@ -40270,6 +41045,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 212
 	AttackMotion: 504
+	DamageDelay: 236
 	DamageMotion: 432
 	MvpExp: 3333333
 	MvpDrops: {
@@ -40327,6 +41103,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 1816
 	AttackMotion: 1152
+	DamageDelay: 450
 	DamageMotion: 360
 	Drops: {
 		Broken_Crown: 9000
@@ -40374,6 +41151,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 1446
 	AttackMotion: 1296
+	DamageDelay: 720
 	DamageMotion: 360
 },
 {
@@ -40450,6 +41228,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 1
 	AttackMotion: 1
+	DamageDelay: 2070
 	DamageMotion: 1
 	Drops: {
 		Love_Flower: 3000
@@ -40501,6 +41280,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1456
 	AttackMotion: 456
+	DamageDelay: 247
 	DamageMotion: 336
 },
 // Moscovia monsters
@@ -40538,6 +41318,7 @@ mob_db: (
 	MoveSpeed: 320
 	AttackDelay: 2304
 	AttackMotion: 840
+	DamageDelay: 337
 	DamageMotion: 360
 	Drops: {
 		Iron_Wrist: 5
@@ -40585,6 +41366,7 @@ mob_db: (
 	MoveSpeed: 230
 	AttackDelay: 1728
 	AttackMotion: 720
+	DamageDelay: 393
 	DamageMotion: 576
 	Drops: {
 		Sharp_Leaf: 2000
@@ -40634,6 +41416,7 @@ mob_db: (
 	MoveSpeed: 270
 	AttackDelay: 1536
 	AttackMotion: 600
+	DamageDelay: 393
 	DamageMotion: 420
 	Drops: {
 		Old_Magic_Circle: 1000
@@ -40683,6 +41466,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 576
 	AttackMotion: 672
+	DamageDelay: 450
 	DamageMotion: 384
 	Drops: {
 		Leaflet_Of_Hinal: 900
@@ -40731,6 +41515,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 1536
 	AttackMotion: 504
+	DamageDelay: 360
 	DamageMotion: 360
 	Drops: {
 		Principles_Of_Magic: 5
@@ -40784,6 +41569,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1536
 	AttackMotion: 864
+	DamageDelay: 607
 	DamageMotion: 432
 	MvpExp: 22625
 	MvpDrops: {
@@ -40838,6 +41624,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 1536
 	AttackMotion: 504
+	DamageDelay: 360
 	DamageMotion: 360
 },
 // Additional Monsters
@@ -41056,6 +41843,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 576
 	AttackMotion: 576
+	DamageDelay: 472
 	DamageMotion: 480
 },
 {
@@ -41096,6 +41884,7 @@ mob_db: (
 	MoveSpeed: 125
 	AttackDelay: 747
 	AttackMotion: 1632
+	DamageDelay: 1530
 	DamageMotion: 576
 },
 {
@@ -41138,6 +41927,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1500
 	AttackMotion: 500
+	DamageDelay: 675
 	DamageMotion: 1000
 },
 {
@@ -41178,6 +41968,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1672
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Cold_Medicine: 8335
@@ -41222,6 +42013,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 },
 {
@@ -41263,6 +42055,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1152
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 },
 {
@@ -41306,6 +42099,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 768
 	AttackMotion: 768
+	DamageDelay: 540
 	DamageMotion: 576
 },
 {
@@ -41345,6 +42139,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 2612
 	AttackMotion: 912
+	DamageDelay: 855
 	DamageMotion: 288
 	Drops: {
 		Jade_Plate: 10000
@@ -41461,6 +42256,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1148
 	AttackMotion: 648
+	DamageDelay: 607
 	DamageMotion: 480
 	Drops: {
 		Heart_Box: 5000
@@ -41582,6 +42378,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1672
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 },
 // WoE Second Edition; Battle Fields
@@ -41618,6 +42415,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 90
 	DamageMotion: 384
 },
 {
@@ -41654,6 +42452,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 90
 	DamageMotion: 384
 },
 {
@@ -41689,6 +42488,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 90
 	DamageMotion: 384
 },
 {
@@ -41724,6 +42524,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 90
 	DamageMotion: 384
 },
 {
@@ -41760,6 +42561,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 270
 	DamageMotion: 384
 },
 {
@@ -41796,6 +42598,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 270
 	DamageMotion: 384
 },
 {
@@ -41832,6 +42635,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 90
 	DamageMotion: 384
 },
 {
@@ -41868,6 +42672,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 90
 	DamageMotion: 384
 },
 {
@@ -41904,6 +42709,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 90
 	DamageMotion: 384
 },
 {
@@ -41940,6 +42746,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 90
 	DamageMotion: 384
 },
 {
@@ -41976,6 +42783,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 90
 	DamageMotion: 384
 },
 // Satan Morroc
@@ -42020,6 +42828,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 540
+	DamageDelay: 315
 	DamageMotion: 432
 },
 {
@@ -42063,6 +42872,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 576
 	AttackMotion: 540
+	DamageDelay: 315
 	DamageMotion: 432
 	MvpExp: 3600000
 	MvpDrops: {
@@ -42120,6 +42930,7 @@ mob_db: (
 	MoveSpeed: 110
 	AttackDelay: 576
 	AttackMotion: 540
+	DamageDelay: 405
 	DamageMotion: 432
 	Drops: {
 		Herald_Of_GOD: 10
@@ -42172,6 +42983,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 576
 	AttackMotion: 540
+	DamageDelay: 337
 	DamageMotion: 432
 	Drops: {
 		Skin_Of_Ventus: 3
@@ -42223,6 +43035,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 212
 	AttackMotion: 540
+	DamageDelay: 202
 	DamageMotion: 432
 	Drops: {
 		Ragamuffin_Cape: 10
@@ -42275,6 +43088,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1536
 	AttackMotion: 540
+	DamageDelay: 405
 	DamageMotion: 432
 	Drops: {
 		Diabolus_Ring: 5
@@ -42327,6 +43141,7 @@ mob_db: (
 	MoveSpeed: 110
 	AttackDelay: 576
 	AttackMotion: 540
+	DamageDelay: 405
 	DamageMotion: 432
 },
 {
@@ -42371,6 +43186,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 576
 	AttackMotion: 540
+	DamageDelay: 337
 	DamageMotion: 432
 },
 {
@@ -42415,6 +43231,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 212
 	AttackMotion: 540
+	DamageDelay: 202
 	DamageMotion: 432
 },
 {
@@ -42459,6 +43276,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1536
 	AttackMotion: 540
+	DamageDelay: 405
 	DamageMotion: 432
 },
 // God Item Creation (WoE SE); Catacombs
@@ -42643,6 +43461,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 768
 	AttackMotion: 768
+	DamageDelay: 360
 	DamageMotion: 576
 	Drops: {
 		Bapho_Doll: 500
@@ -42696,6 +43515,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 432
 	AttackMotion: 768
+	DamageDelay: 270
 	DamageMotion: 576
 },
 {
@@ -42739,6 +43559,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 576
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 480
 },
 {
@@ -42776,6 +43597,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 768
 	AttackMotion: 768
+	DamageDelay: 270
 	DamageMotion: 576
 	Drops: {
 		Crystal_Key: 9000
@@ -42822,6 +43644,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 432
 	AttackMotion: 480
+	DamageDelay: 337
 	DamageMotion: 360
 },
 {
@@ -42857,6 +43680,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 768
 	AttackMotion: 768
+	DamageDelay: 90
 	DamageMotion: 576
 },
 {
@@ -42892,6 +43716,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 768
 	AttackMotion: 768
+	DamageDelay: 90
 	DamageMotion: 576
 },
 {
@@ -42927,6 +43752,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 768
 	AttackMotion: 768
+	DamageDelay: 90
 	DamageMotion: 576
 },
 {
@@ -42966,6 +43792,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 720
 	AttackMotion: 360
+	DamageDelay: 337
 	DamageMotion: 360
 },
 {
@@ -43414,6 +44241,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 432
 	AttackMotion: 768
+	DamageDelay: 270
 	DamageMotion: 576
 },
 {
@@ -43453,6 +44281,7 @@ mob_db: (
 	MoveSpeed: 145
 	AttackDelay: 576
 	AttackMotion: 432
+	DamageDelay: 270
 	DamageMotion: 288
 },
 {
@@ -43797,6 +44626,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 432
+	DamageDelay: 315
 	DamageMotion: 504
 	Drops: {
 		Twin_Edge_B: 9000
@@ -43843,6 +44673,7 @@ mob_db: (
 	MoveSpeed: 0
 	AttackDelay: 140
 	AttackMotion: 540
+	DamageDelay: 506
 	DamageMotion: 576
 	Drops: {
 		Thorn_Staff: 9000
@@ -44038,6 +44869,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 720
 	AttackMotion: 720
+	DamageDelay: 405
 	DamageMotion: 432
 },
 {
@@ -44079,6 +44911,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 1728
 	AttackMotion: 816
+	DamageDelay: 225
 	DamageMotion: 1188
 },
 {
@@ -44154,6 +44987,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 964
 	AttackMotion: 864
+	DamageDelay: 787
 	DamageMotion: 288
 },
 {
@@ -44189,6 +45023,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 300
 	AttackMotion: 480
+	DamageDelay: 180
 	DamageMotion: 288
 },
 {
@@ -44225,6 +45060,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 300
 	AttackMotion: 480
+	DamageDelay: 270
 	DamageMotion: 288
 },
 {
@@ -44260,6 +45096,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 101
 	DamageMotion: 384
 	Drops: {
 		Fin: 5335
@@ -44305,6 +45142,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1272
 	AttackMotion: 72
+	DamageDelay: 202
 	DamageMotion: 480
 	Drops: {
 		Mistic_Frozen: 36
@@ -44351,6 +45189,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 360
 	DamageMotion: 288
 	Drops: {
 		Mistic_Frozen: 26
@@ -44396,6 +45235,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1632
 	AttackMotion: 432
+	DamageDelay: 393
 	DamageMotion: 540
 	Drops: {
 		Crystal_Blue: 40
@@ -44441,6 +45281,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 2280
 	AttackMotion: 1080
+	DamageDelay: 675
 	DamageMotion: 864
 	Drops: {
 		Single_Cell: 5000
@@ -44485,6 +45326,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Jellopy: 7000
@@ -44535,6 +45377,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 676
 	AttackMotion: 504
+	DamageDelay: 405
 	DamageMotion: 504
 	Drops: {
 		Brigan: 5335
@@ -44584,6 +45427,7 @@ mob_db: (
 	MoveSpeed: 190
 	AttackDelay: 336
 	AttackMotion: 840
+	DamageDelay: 225
 	DamageMotion: 360
 	Drops: {
 		Prickly_Fruit: 3000
@@ -44632,6 +45476,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 648
 	AttackMotion: 480
+	DamageDelay: 337
 	DamageMotion: 360
 	Drops: {
 		Fragment_Of_Crystal: 3000
@@ -44681,6 +45526,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 384
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Tube: 4000
@@ -44730,6 +45576,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1840
 	AttackMotion: 1440
+	DamageDelay: 495
 	DamageMotion: 384
 	Drops: {
 		Broken_Steel_Piece: 5335
@@ -44780,6 +45627,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 580
 	AttackMotion: 288
+	DamageDelay: 225
 	DamageMotion: 360
 	Drops: {
 		Screw: 5000
@@ -44833,6 +45681,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 964
 	AttackMotion: 648
+	DamageDelay: 337
 	DamageMotion: 300
 	MvpExp: 100000
 	MvpDrops: {
@@ -44887,6 +45736,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1500
 	AttackMotion: 500
+	DamageDelay: 405
 	DamageMotion: 1000
 },
 {
@@ -44927,6 +45777,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1960
 	AttackMotion: 620
+	DamageDelay: 810
 	DamageMotion: 480
 },
 {
@@ -44967,6 +45818,7 @@ mob_db: (
 	MoveSpeed: 130
 	AttackDelay: 2420
 	AttackMotion: 720
+	DamageDelay: 270
 	DamageMotion: 648
 },
 {
@@ -45009,6 +45861,7 @@ mob_db: (
 	MoveSpeed: 145
 	AttackDelay: 1050
 	AttackMotion: 900
+	DamageDelay: 506
 	DamageMotion: 288
 },
 // Another World (13.1)
@@ -45051,6 +45904,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1772
 	AttackMotion: 72
+	DamageDelay: 472
 	DamageMotion: 384
 },
 {
@@ -45089,6 +45943,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1000
 	AttackMotion: 768
+	DamageDelay: 450
 	DamageMotion: 360
 	Drops: {
 		Lunakaligo: 20
@@ -45140,6 +45995,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1000
 	AttackMotion: 792
+	DamageDelay: 540
 	DamageMotion: 336
 	Drops: {
 		Cold_Heart: 2
@@ -45185,6 +46041,7 @@ mob_db: (
 	MoveSpeed: 1000
 	AttackDelay: 500
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 504
 	Drops: {
 		Mandragora_Cap: 1
@@ -45233,6 +46090,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 400
 	AttackMotion: 780
+	DamageDelay: 450
 	DamageMotion: 576
 	Drops: {
 		Sprint_Shoes: 10
@@ -45286,6 +46144,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1000
 	AttackMotion: 660
+	DamageDelay: 281
 	DamageMotion: 588
 	Drops: {
 		Bone_Head: 100
@@ -45338,6 +46197,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 500
 	AttackMotion: 960
+	DamageDelay: 731
 	DamageMotion: 360
 	Drops: {
 		Leather_Of_Tendrilion: 500
@@ -45384,6 +46244,7 @@ mob_db: (
 	MoveSpeed: 120
 	AttackDelay: 1000
 	AttackMotion: 624
+	DamageDelay: 180
 	DamageMotion: 300
 	Drops: {
 		Sprint_Mail: 10
@@ -45435,6 +46296,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 400
 	AttackMotion: 864
+	DamageDelay: 675
 	DamageMotion: 432
 	Drops: {
 		Armor_Of_Naga: 10
@@ -45487,6 +46349,7 @@ mob_db: (
 	MoveSpeed: 110
 	AttackDelay: 1000
 	AttackMotion: 864
+	DamageDelay: 675
 	DamageMotion: 432
 	Drops: {
 		Sprint_Ring: 2
@@ -45536,6 +46399,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 700
 	AttackMotion: 600
+	DamageDelay: 281
 	DamageMotion: 360
 	Drops: {
 		Pinguicula_Corsage: 1
@@ -45631,6 +46495,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1000
 	AttackMotion: 768
+	DamageDelay: 450
 	DamageMotion: 360
 },
 {
@@ -45670,6 +46535,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 400
 	AttackMotion: 780
+	DamageDelay: 450
 	DamageMotion: 576
 },
 {
@@ -45712,6 +46578,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1000
 	AttackMotion: 792
+	DamageDelay: 540
 	DamageMotion: 336
 	Drops: {
 		Boots_: 9
@@ -45756,6 +46623,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 300
 	AttackMotion: 384
+	DamageDelay: 360
 	DamageMotion: 288
 },
 {
@@ -45791,6 +46659,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 300
 	AttackMotion: 384
+	DamageDelay: 360
 	DamageMotion: 288
 },
 {
@@ -45826,6 +46695,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 1120
 	AttackMotion: 552
+	DamageDelay: 708
 	DamageMotion: 511
 	Drops: {
 		Moon_Cake: 1000
@@ -45872,6 +46742,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 576
 	AttackMotion: 960
+	DamageDelay: 900
 	DamageMotion: 480
 	Drops: {
 		Moon_Cake1: 1000
@@ -45922,6 +46793,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 637
 	AttackMotion: 1008
+	DamageDelay: 540
 	DamageMotion: 360
 	Drops: {
 		Moon_Cake1: 800
@@ -45966,6 +46838,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 608
 	AttackMotion: 1440
+	DamageDelay: 1215
 	DamageMotion: 576
 	Drops: {
 		Moon_Cake1: 500
@@ -46008,6 +46881,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 608
 	AttackMotion: 1440
+	DamageDelay: 1215
 	DamageMotion: 576
 	Drops: {
 		Moon_Cake15: 500
@@ -46050,6 +46924,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 608
 	AttackMotion: 1440
+	DamageDelay: 1215
 	DamageMotion: 576
 	Drops: {
 		Moon_Cake1: 500
@@ -46178,6 +47053,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1100
 	AttackMotion: 960
+	DamageDelay: 1800
 	DamageMotion: 780
 },
 /*{
@@ -46213,6 +47089,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 2456
 	AttackMotion: 912
+	DamageDelay: 427
 	DamageMotion: 504
 },
 {
@@ -46248,6 +47125,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 2612
 	AttackMotion: 912
+	DamageDelay: 855
 	DamageMotion: 288
 },*/
 // Another World (13.2)
@@ -46286,6 +47164,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 576
 	AttackMotion: 960
+	DamageDelay: 393
 	DamageMotion: 504
 	Drops: {
 		Dragons_Mane: 3000
@@ -46326,6 +47205,7 @@ mob_db: (
 	MoveSpeed: 1000
 	AttackDelay: 24
 	AttackMotion: 0
+	DamageDelay: 22
 	DamageMotion: 0
 	Drops: {
 		Piece_Of_Egg_Shell: 5000
@@ -46369,6 +47249,7 @@ mob_db: (
 	MoveSpeed: 290
 	AttackDelay: 1426
 	AttackMotion: 600
+	DamageDelay: 337
 	DamageMotion: 360
 	Drops: {
 		Sharp_Leaf: 5000
@@ -46415,6 +47296,7 @@ mob_db: (
 	MoveSpeed: 230
 	AttackDelay: 504
 	AttackMotion: 960
+	DamageDelay: 450
 	DamageMotion: 576
 	Drops: {
 		Crystalized_Teardrop: 1000
@@ -46461,6 +47343,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 792
 	AttackMotion: 540
+	DamageDelay: 393
 	DamageMotion: 420
 	Drops: {
 		Unripe_Acorn: 5000
@@ -46507,6 +47390,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 672
 	AttackMotion: 420
+	DamageDelay: 281
 	DamageMotion: 360
 	Drops: {
 		Carrot: 5000
@@ -46554,6 +47438,7 @@ mob_db: (
 	MoveSpeed: 290
 	AttackDelay: 504
 	AttackMotion: 960
+	DamageDelay: 450
 	DamageMotion: 576
 	Drops: {
 		Tough_Vines: 1000
@@ -46600,6 +47485,7 @@ mob_db: (
 	MoveSpeed: 240
 	AttackDelay: 576
 	AttackMotion: 660
+	DamageDelay: 281
 	DamageMotion: 420
 	Drops: {
 		Fluorescent_Liquid: 5000
@@ -46642,6 +47528,7 @@ mob_db: (
 	MoveSpeed: 240
 	AttackDelay: 360
 	AttackMotion: 780
+	DamageDelay: 506
 	DamageMotion: 432
 	Drops: {
 		Fluorescent_Liquid: 5000
@@ -46691,6 +47578,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1596
 	AttackMotion: 1620
+	DamageDelay: 540
 	DamageMotion: 864
 	MvpExp: 2400000
 	Drops: {
@@ -46741,6 +47629,7 @@ mob_db: (
 	MoveSpeed: 220
 	AttackDelay: 768
 	AttackMotion: 1776
+	DamageDelay: 855
 	DamageMotion: 648
 	Drops: {
 		Piece_Of_Black_Cloth: 5000
@@ -46790,6 +47679,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1008
 	AttackMotion: 1200
+	DamageDelay: 450
 	DamageMotion: 540
 	Drops: {
 		Stone_Piece: 3000
@@ -46882,6 +47772,7 @@ mob_db: (
 	MoveSpeed: 230
 	AttackDelay: 1772
 	AttackMotion: 72
+	DamageDelay: 472
 	DamageMotion: 384
 	Drops: {
 		Old_Frying_Pan: 5000
@@ -46934,6 +47825,7 @@ mob_db: (
 	MoveSpeed: 220
 	AttackDelay: 768
 	AttackMotion: 1776
+	DamageDelay: 855
 	DamageMotion: 648
 },
 /*{
@@ -47219,6 +48111,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1600
 	AttackMotion: 900
+	DamageDelay: 236
 	DamageMotion: 240
 },
 {
@@ -47255,6 +48148,7 @@ mob_db: (
 	MoveSpeed: 1000
 	AttackDelay: 1001
 	AttackMotion: 1
+	DamageDelay: 90
 	DamageMotion: 1
 },
 {
@@ -47702,6 +48596,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 400
 	AttackMotion: 864
+	DamageDelay: 675
 	DamageMotion: 432
 	Drops: {
 		Scale_Of_Snakes: 5000
@@ -47740,6 +48635,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 337
 	DamageMotion: 480
 },*/
 {
@@ -47780,6 +48676,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1008
 	AttackMotion: 1200
+	DamageDelay: 450
 	DamageMotion: 540
 	Drops: {
 		Purified_Bradium: 500
@@ -47818,6 +48715,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 450
 	DamageMotion: 480
 },
 {
@@ -47853,6 +48751,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 768
 	AttackMotion: 768
+	DamageDelay: 540
 	DamageMotion: 576
 	Drops: {
 		Fools_Day_Box: 5000
@@ -47892,6 +48791,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 382
 	DamageMotion: 480
 },
 {
@@ -47927,6 +48827,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 315
 	DamageMotion: 480
 },
 {
@@ -48068,6 +48969,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 607
 	DamageMotion: 480
 },
 /*{
@@ -48103,6 +49005,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 450
 	DamageMotion: 480
 },
 {
@@ -48138,6 +49041,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 337
 	DamageMotion: 480
 },
 {
@@ -48173,6 +49077,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 2160
 	DamageMotion: 480
 },
 {
@@ -48383,6 +49288,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 360
 	DamageMotion: 480
 },
 {
@@ -48418,6 +49324,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 360
 	DamageMotion: 480
 },*/
 {
@@ -48461,6 +49368,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1150
 	AttackMotion: 1150
+	DamageDelay: 225
 	DamageMotion: 288
 	MvpExp: 37144
 	Drops: {
@@ -48507,6 +49415,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 672
 	AttackMotion: 380
+	DamageDelay: 360
 	DamageMotion: 288
 	Drops: {
 		Heart_Of_Mermaid: 9000
@@ -48556,6 +49465,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 768
 	AttackMotion: 768
+	DamageDelay: 270
 	DamageMotion: 384
 	Drops: {
 		Sharp_Scale: 9000
@@ -48605,6 +49515,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1216
 	AttackMotion: 816
+	DamageDelay: 270
 	DamageMotion: 432
 	Drops: {
 		Burning_Horse_Shoe: 4000
@@ -48653,6 +49564,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1250
 	AttackMotion: 580
+	DamageDelay: 405
 	DamageMotion: 360
 	Drops: {
 		Leopard_Skin: 3000
@@ -48699,6 +49611,7 @@ mob_db: (
 	MoveSpeed: 155
 	AttackDelay: 1450
 	AttackMotion: 960
+	DamageDelay: 281
 	DamageMotion: 480
 	Drops: {
 		Talon: 3000
@@ -48745,6 +49658,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 530
 	AttackMotion: 530
+	DamageDelay: 180
 	DamageMotion: 384
 	Drops: {
 		Meat: 3000
@@ -48787,6 +49701,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 393
 	DamageMotion: 480
 },*/
 {
@@ -48829,6 +49744,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1056
 	AttackMotion: 1056
+	DamageDelay: 675
 	DamageMotion: 336
 },
 {
@@ -48870,6 +49786,7 @@ mob_db: (
 	MoveSpeed: 190
 	AttackDelay: 720
 	AttackMotion: 384
+	DamageDelay: 337
 	DamageMotion: 480
 },
 {
@@ -48912,6 +49829,7 @@ mob_db: (
 	MoveSpeed: 155
 	AttackDelay: 1306
 	AttackMotion: 1056
+	DamageDelay: 540
 	DamageMotion: 288
 },
 /*{
@@ -48947,6 +49865,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 1080
 	DamageMotion: 480
 },
 {
@@ -48982,6 +49901,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 1080
 	DamageMotion: 480
 },*/
 {
@@ -49014,6 +49934,7 @@ mob_db: (
 	MoveSpeed: 1000
 	AttackDelay: 800
 	AttackMotion: 432
+	DamageDelay: 315
 	DamageMotion: 600
 },
 {
@@ -49054,6 +49975,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 768
 	AttackMotion: 768
+	DamageDelay: 270
 	DamageMotion: 384
 },
 {
@@ -49090,6 +50012,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1456
 	AttackMotion: 456
+	DamageDelay: 247
 	DamageMotion: 336
 },
 {
@@ -49156,6 +50079,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 2520
 	DamageMotion: 480
 //	Drops: {
 //		Blue_Card_C: 4000

--- a/db/re/mob_db.conf
+++ b/db/re/mob_db.conf
@@ -149,6 +149,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1564
 	AttackMotion: 864
+	DamageDelay: 360
 	DamageMotion: 576
 	Drops: {
 		Boody_Red: 70
@@ -195,6 +196,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Jellopy: 7000
@@ -273,6 +275,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1292
 	AttackMotion: 792
+	DamageDelay: 742
 	DamageMotion: 216
 	Drops: {
 		Wind_Of_Verdure: 80
@@ -320,6 +323,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1276
 	AttackMotion: 576
+	DamageDelay: 540
 	DamageMotion: 384
 	Drops: {
 		Tooth_Of_Bat: 5500
@@ -404,6 +408,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1672
 	AttackMotion: 672
+	DamageDelay: 180
 	DamageMotion: 480
 	Drops: {
 		Fluff: 6500
@@ -448,6 +453,7 @@ mob_db: (
 	MoveSpeed: 1000
 	AttackDelay: 1001
 	AttackMotion: 1
+	DamageDelay: 900
 	DamageMotion: 1
 	Drops: {
 		Phracon: 80
@@ -494,6 +500,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1148
 	AttackMotion: 648
+	DamageDelay: 607
 	DamageMotion: 480
 	Drops: {
 		Talon: 9000
@@ -539,6 +546,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1672
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 432
 	Drops: {
 		Tree_Root: 9000
@@ -585,6 +593,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1076
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Iron: 50
@@ -630,6 +639,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 2016
 	AttackMotion: 816
+	DamageDelay: 315
 	DamageMotion: 288
 	Drops: {
 		Sticky_Webfoot: 9000
@@ -675,6 +685,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1054
 	AttackMotion: 504
+	DamageDelay: 202
 	DamageMotion: 432
 	Drops: {
 		Emveretarcon: 20
@@ -720,6 +731,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 630
 	DamageMotion: 288
 	Drops: {
 		Mushroom_Spore: 9000
@@ -769,6 +781,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 2612
 	AttackMotion: 912
+	DamageDelay: 855
 	DamageMotion: 288
 	Drops: {
 		Decayed_Nail: 9000
@@ -814,6 +827,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 2864
 	AttackMotion: 864
+	DamageDelay: 630
 	DamageMotion: 576
 	Drops: {
 		Skel_Bone: 4500
@@ -908,6 +922,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1136
 	AttackMotion: 720
+	DamageDelay: 405
 	DamageMotion: 840
 	Drops: {
 		Powder_Of_Butterfly: 9000
@@ -955,6 +970,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1564
 	AttackMotion: 864
+	DamageDelay: 450
 	DamageMotion: 576
 	Drops: {
 		Bill_Of_Birds: 9000
@@ -999,6 +1015,7 @@ mob_db: (
 	MoveSpeed: 1000
 	AttackDelay: 1768
 	AttackMotion: 768
+	DamageDelay: 360
 	DamageMotion: 576
 	Drops: {
 		Yellow_Live: 50
@@ -1143,6 +1160,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1864
 	AttackMotion: 864
+	DamageDelay: 810
 	DamageMotion: 288
 	Drops: {
 		Iron: 210
@@ -1189,6 +1207,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1048
 	AttackMotion: 48
+	DamageDelay: 270
 	DamageMotion: 192
 	Drops: {
 		Yellow_Live: 60
@@ -1235,6 +1254,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1576
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 576
 	Drops: {
 		Scale_Of_Snakes: 9000
@@ -1284,6 +1304,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 2468
 	AttackMotion: 768
+	DamageDelay: 450
 	DamageMotion: 288
 	Drops: {
 		Danggie: 9000
@@ -1373,6 +1394,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 2276
 	AttackMotion: 576
+	DamageDelay: 202
 	DamageMotion: 432
 	Drops: {
 		Skel_Bone: 5500
@@ -1423,6 +1445,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1384
 	AttackMotion: 768
+	DamageDelay: 450
 	DamageMotion: 336
 	Drops: {
 		Scales_Shell: 5335
@@ -1469,6 +1492,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1576
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 576
 	Drops: {
 		White_Powder: 200
@@ -1515,6 +1539,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1672
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Sticky_Mucus: 5500
@@ -1561,6 +1586,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 2468
 	AttackMotion: 768
+	DamageDelay: 450
 	DamageMotion: 480
 	Drops: {
 		Immortal_Heart: 9000
@@ -1610,6 +1636,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1372
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 432
 	Drops: {
 		Boody_Red: 50
@@ -1655,6 +1682,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 2016
 	AttackMotion: 816
+	DamageDelay: 315
 	DamageMotion: 288
 	Drops: {
 		Emveretarcon: 45
@@ -1704,6 +1732,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 676
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Rough_Wind: 30
@@ -1753,6 +1782,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 2456
 	AttackMotion: 912
+	DamageDelay: 427
 	DamageMotion: 504
 	Drops: {
 		Horrendous_Mouth: 6000
@@ -1802,6 +1832,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1576
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 576
 	Drops: {
 		Shining_Scales: 5335
@@ -1855,6 +1886,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1072
 	AttackMotion: 672
+	DamageDelay: 180
 	DamageMotion: 384
 	DamageTakenRate: 10
 	MvpExp: 122760
@@ -1915,6 +1947,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 768
 	AttackMotion: 768
+	DamageDelay: 540
 	DamageMotion: 576
 	DamageTakenRate: 10
 	MvpExp: 198262
@@ -1968,6 +2001,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1608
 	AttackMotion: 816
+	DamageDelay: 945
 	DamageMotion: 396
 	Drops: {
 		Steel: 150
@@ -2017,6 +2051,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1772
 	AttackMotion: 72
+	DamageDelay: 270
 	DamageMotion: 384
 	Drops: {
 		Rotten_Bandage: 9000
@@ -2066,6 +2101,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1076
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Wind_Of_Verdure: 90
@@ -2152,6 +2188,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 360
 	DamageMotion: 288
 	Drops: {
 		Mistic_Frozen: 13
@@ -2201,6 +2238,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1272
 	AttackMotion: 72
+	DamageDelay: 202
 	DamageMotion: 480
 	Drops: {
 		Mistic_Frozen: 18
@@ -2254,6 +2292,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 480
 	AttackMotion: 480
+	DamageDelay: 180
 	DamageMotion: 288
 	DamageTakenRate: 10
 	MvpExp: 156600
@@ -2301,6 +2340,7 @@ mob_db: (
 	MoveSpeed: 1000
 	AttackDelay: 1001
 	AttackMotion: 1
+	DamageDelay: 810
 	DamageMotion: 1
 	Drops: {
 		Phracon: 250
@@ -2345,6 +2385,7 @@ mob_db: (
 	MoveSpeed: 1000
 	AttackDelay: 701
 	AttackMotion: 1
+	DamageDelay: 450
 	DamageMotion: 1
 	Drops: {
 		Phracon: 300
@@ -2390,6 +2431,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 988
 	AttackMotion: 288
+	DamageDelay: 270
 	DamageMotion: 168
 	Drops: {
 		Feather_Of_Birds: 9000
@@ -2434,6 +2476,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 988
 	AttackMotion: 288
+	DamageDelay: 270
 	DamageMotion: 168
 	Drops: {
 		Feather_Of_Birds: 9000
@@ -2482,6 +2525,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 720
 	DamageMotion: 768
 	Drops: {
 		Worm_Peelings: 2500
@@ -2527,6 +2571,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1864
 	AttackMotion: 864
+	DamageDelay: 810
 	DamageMotion: 540
 	Drops: {
 		Grasshoppers_Leg: 9000
@@ -2577,6 +2622,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 988
 	AttackMotion: 288
+	DamageDelay: 720
 	DamageMotion: 768
 	Drops: {
 		Worm_Peelings: 3500
@@ -2628,6 +2674,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 988
 	AttackMotion: 288
+	DamageDelay: 720
 	DamageMotion: 768
 	Drops: {
 		Emveretarcon: 40
@@ -2673,6 +2720,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1960
 	AttackMotion: 960
+	DamageDelay: 450
 	DamageMotion: 384
 	Drops: {
 		Yellow_Live: 70
@@ -2719,6 +2767,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1576
 	AttackMotion: 576
+	DamageDelay: 540
 	DamageMotion: 420
 	Drops: {
 		Raccoon_Leaf: 5500
@@ -2767,6 +2816,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1054
 	AttackMotion: 54
+	DamageDelay: 472
 	DamageMotion: 384
 	Drops: {
 		Yoyo_Tail: 9000
@@ -2816,6 +2866,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1708
 	AttackMotion: 1008
+	DamageDelay: 472
 	DamageMotion: 540
 	Drops: {
 		Boody_Red: 60
@@ -2869,6 +2920,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1148
 	AttackMotion: 648
+	DamageDelay: 607
 	DamageMotion: 300
 	DamageTakenRate: 10
 	MvpExp: 184140
@@ -2922,6 +2974,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1260
 	AttackMotion: 192
+	DamageDelay: 1181
 	DamageMotion: 192
 	Drops: {
 		Bears_Foot: 9000
@@ -2973,6 +3026,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1816
 	AttackMotion: 816
+	DamageDelay: 765
 	DamageMotion: 432
 	Drops: {
 		Horseshoe: 6000
@@ -3018,6 +3072,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1672
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Candy: 2000
@@ -3062,6 +3117,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1456
 	AttackMotion: 456
+	DamageDelay: 247
 	DamageMotion: 336
 	Drops: {
 		Clover: 6500
@@ -3107,6 +3163,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 2492
 	AttackMotion: 792
+	DamageDelay: 652
 	DamageMotion: 432
 	Drops: {
 		Rotten_Scale: 5500
@@ -3156,6 +3213,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 101
 	DamageMotion: 384
 	Drops: {
 		Fin: 5335
@@ -3202,6 +3260,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1632
 	AttackMotion: 432
+	DamageDelay: 393
 	DamageMotion: 540
 	Drops: {
 		Crystal_Blue: 40
@@ -3248,6 +3307,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1248
 	AttackMotion: 48
+	DamageDelay: 180
 	DamageMotion: 480
 	Drops: {
 		Crystal_Blue: 45
@@ -3293,6 +3353,7 @@ mob_db: (
 	MoveSpeed: 1000
 	AttackDelay: 800
 	AttackMotion: 432
+	DamageDelay: 315
 	DamageMotion: 600
 	Drops: {
 		Emveretarcon: 25
@@ -3341,6 +3402,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1968
 	AttackMotion: 768
+	DamageDelay: 180
 	DamageMotion: 384
 	Drops: {
 		Mistic_Frozen: 10
@@ -3387,6 +3449,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1776
 	AttackMotion: 576
+	DamageDelay: 540
 	DamageMotion: 288
 	Drops: {
 		Crystal_Blue: 30
@@ -3436,6 +3499,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1754
 	AttackMotion: 554
+	DamageDelay: 337
 	DamageMotion: 288
 	Drops: {
 		Skel_Bone: 3000
@@ -3486,6 +3550,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1700
 	AttackMotion: 1000
+	DamageDelay: 405
 	DamageMotion: 500
 	Drops: {
 		Flame_Heart: 30
@@ -3531,6 +3596,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 992
 	AttackMotion: 792
+	DamageDelay: 270
 	DamageMotion: 360
 	Drops: {
 		Crap_Shell: 5500
@@ -3575,6 +3641,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 864
 	AttackMotion: 864
+	DamageDelay: 438
 	DamageMotion: 384
 	Drops: {
 		Clam_Shell: 5500
@@ -3655,6 +3722,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 2228
 	AttackMotion: 528
+	DamageDelay: 315
 	DamageMotion: 576
 	Drops: {
 		Phracon: 90
@@ -3703,6 +3771,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1672
 	AttackMotion: 672
+	DamageDelay: 630
 	DamageMotion: 288
 	Drops: {
 		Poison_Spore: 9000
@@ -3747,6 +3816,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 1
 	AttackMotion: 1
+	DamageDelay: 1080
 	DamageMotion: 1
 	Drops: {
 		Red_Herb: 5500
@@ -3791,6 +3861,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 1
 	AttackMotion: 1
+	DamageDelay: 1080
 	DamageMotion: 1
 	Drops: {
 		Blue_Herb: 5500
@@ -3835,6 +3906,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 1
 	AttackMotion: 1
+	DamageDelay: 1080
 	DamageMotion: 1
 	Drops: {
 		Green_Herb: 7000
@@ -3879,6 +3951,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 1
 	AttackMotion: 1
+	DamageDelay: 1080
 	DamageMotion: 1
 	Drops: {
 		Yellow_Herb: 5500
@@ -3923,6 +3996,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 1
 	AttackMotion: 1
+	DamageDelay: 1080
 	DamageMotion: 1
 	Drops: {
 		White_Herb: 5500
@@ -3967,6 +4041,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 1
 	AttackMotion: 1
+	DamageDelay: 2070
 	DamageMotion: 1
 	Drops: {
 		Blue_Herb: 5500
@@ -4011,6 +4086,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 1
 	AttackMotion: 1
+	DamageDelay: 90
 	DamageMotion: 1
 	Drops: {
 		Alchol: 50
@@ -4055,6 +4131,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 1
 	AttackMotion: 1
+	DamageDelay: 90
 	DamageMotion: 1
 	Drops: {
 		Alchol: 50
@@ -4105,6 +4182,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 768
 	AttackMotion: 768
+	DamageDelay: 720
 	DamageMotion: 480
 	DamageTakenRate: 10
 	MvpExp: 97200
@@ -4164,6 +4242,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1678
 	AttackMotion: 780
+	DamageDelay: 731
 	DamageMotion: 648
 	DamageTakenRate: 10
 	MvpExp: 53460
@@ -4223,6 +4302,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1080
 	AttackMotion: 648
+	DamageDelay: 607
 	DamageMotion: 480
 	Drops: {
 		Oldmans_Romance: 50
@@ -4276,6 +4356,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1236
 	AttackMotion: 336
+	DamageDelay: 157
 	DamageMotion: 432
 	Drops: {
 		Big_Sis_Ribbon: 50
@@ -4329,6 +4410,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1072
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Snowy_Horn: 200
@@ -4382,6 +4464,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1076
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Sweet_Gents: 200
@@ -4435,6 +4518,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1048
 	AttackMotion: 648
+	DamageDelay: 202
 	DamageMotion: 432
 	Drops: {
 		Western_Grace: 200
@@ -4488,6 +4572,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1456
 	AttackMotion: 456
+	DamageDelay: 247
 	DamageMotion: 336
 	Drops: {
 		Fillet: 200
@@ -4535,6 +4620,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 2048
 	AttackMotion: 648
+	DamageDelay: 292
 	DamageMotion: 648
 	Drops: {
 		Crystal_Blue: 50
@@ -4582,6 +4668,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 168
 	DamageMotion: 384
 	Drops: {
 		Worm_Peelings: 9000
@@ -4635,6 +4722,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1072
 	AttackMotion: 672
+	DamageDelay: 292
 	DamageMotion: 672
 	Drops: {
 		Angelic_Chain: 100
@@ -4676,6 +4764,7 @@ mob_db: (
 	MoveSpeed: 1000
 	AttackDelay: 1001
 	AttackMotion: 1
+	DamageDelay: 720
 	DamageMotion: 1
 	Drops: {
 		Phracon: 320
@@ -4726,6 +4815,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1250
 	AttackMotion: 720
+	DamageDelay: 450
 	DamageMotion: 576
 	Drops: {
 		Runstone_Ancient: 10
@@ -4778,6 +4868,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1792
 	AttackMotion: 792
+	DamageDelay: 540
 	DamageMotion: 336
 	Drops: {
 		Short_Leg: 5335
@@ -4827,6 +4918,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1468
 	AttackMotion: 468
+	DamageDelay: 202
 	DamageMotion: 768
 	Drops: {
 		Spiderweb: 9000
@@ -4879,6 +4971,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 868
 	AttackMotion: 480
+	DamageDelay: 202
 	DamageMotion: 120
 	Drops: {
 		Evil_Horn: 500
@@ -4930,6 +5023,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1504
 	AttackMotion: 840
+	DamageDelay: 270
 	DamageMotion: 900
 	Drops: {
 		Sparkling_Dust: 200
@@ -4976,6 +5070,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1604
 	AttackMotion: 840
+	DamageDelay: 202
 	DamageMotion: 756
 	Drops: {
 		Porcupine_Spike: 9000
@@ -5021,6 +5116,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1864
 	AttackMotion: 864
+	DamageDelay: 472
 	DamageMotion: 1008
 	Drops: {
 		Acorn: 9000
@@ -5068,6 +5164,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 135
 	DamageMotion: 576
 	Drops: {
 		Worm_Peelings: 9000
@@ -5117,6 +5214,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1120
 	AttackMotion: 420
+	DamageDelay: 168
 	DamageMotion: 288
 	Drops: {
 		Katar_: 1
@@ -5164,6 +5262,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1600
 	AttackMotion: 900
+	DamageDelay: 236
 	DamageMotion: 240
 	Drops: {
 		Phracon: 85
@@ -5210,6 +5309,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1680
 	AttackMotion: 480
+	DamageDelay: 270
 	DamageMotion: 384
 	Drops: {
 		Mistic_Frozen: 25
@@ -5262,6 +5362,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 980
 	AttackMotion: 600
+	DamageDelay: 270
 	DamageMotion: 384
 	Drops: {
 		Petite_DiablOfs_Horn: 5335
@@ -5309,6 +5410,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1156
 	AttackMotion: 456
+	DamageDelay: 270
 	DamageMotion: 384
 	Drops: {
 		Dokkaebi_Horn: 9000
@@ -5358,6 +5460,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1276
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 384
 	Drops: {
 		Emveretarcon: 60
@@ -5411,6 +5514,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 620
 	AttackMotion: 420
+	DamageDelay: 101
 	DamageMotion: 360
 	DamageTakenRate: 10
 	MvpExp: 257580
@@ -5463,6 +5567,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1372
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Jellopy: 7500
@@ -5510,6 +5615,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1004
 	AttackMotion: 504
+	DamageDelay: 236
 	DamageMotion: 384
 	Drops: {
 		Moth_Dust: 9000
@@ -5562,6 +5668,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 872
 	AttackMotion: 1344
+	DamageDelay: 382
 	DamageMotion: 432
 	DamageTakenRate: 10
 	MvpExp: 99000
@@ -5615,6 +5722,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1816
 	AttackMotion: 816
+	DamageDelay: 450
 	DamageMotion: 288
 	Drops: {
 		Scell: 1000
@@ -5666,6 +5774,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 2276
 	AttackMotion: 576
+	DamageDelay: 157
 	DamageMotion: 336
 	Drops: {
 		Biretta_: 10
@@ -5711,6 +5820,7 @@ mob_db: (
 	MoveSpeed: 1000
 	AttackDelay: 1432
 	AttackMotion: 432
+	DamageDelay: 168
 	DamageMotion: 576
 	Drops: {
 		Blossom_Of_Maneater: 9000
@@ -5760,6 +5870,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1540
 	AttackMotion: 720
+	DamageDelay: 303
 	DamageMotion: 432
 	Drops: {
 		Lizard_Scruff: 5500
@@ -5813,6 +5924,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1220
 	AttackMotion: 1080
+	DamageDelay: 315
 	DamageMotion: 648
 	Drops: {
 		Transparent_Cloth: 5335
@@ -5860,6 +5972,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1848
 	AttackMotion: 1296
+	DamageDelay: 450
 	DamageMotion: 432
 	Drops: {
 		Great_Nature: 30
@@ -5910,6 +6023,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1120
 	AttackMotion: 620
+	DamageDelay: 360
 	DamageMotion: 240
 	Drops: {
 		Iron: 270
@@ -5959,6 +6073,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1320
 	AttackMotion: 620
+	DamageDelay: 360
 	DamageMotion: 240
 	Drops: {
 		Iron: 250
@@ -6008,6 +6123,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1624
 	AttackMotion: 624
+	DamageDelay: 360
 	DamageMotion: 240
 	Drops: {
 		Iron: 230
@@ -6057,6 +6173,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1624
 	AttackMotion: 624
+	DamageDelay: 360
 	DamageMotion: 240
 	Drops: {
 		Yellow_Live: 100
@@ -6106,6 +6223,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 3074
 	AttackMotion: 1874
+	DamageDelay: 360
 	DamageMotion: 480
 	Drops: {
 		Iron: 150
@@ -6151,6 +6269,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1480
 	AttackMotion: 480
+	DamageDelay: 270
 	DamageMotion: 720
 	Drops: {
 		Yellow_Live: 120
@@ -6198,6 +6317,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1528
 	AttackMotion: 528
+	DamageDelay: 315
 	DamageMotion: 288
 	Drops: {
 		Yellow_Live: 80
@@ -6246,6 +6366,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1888
 	AttackMotion: 1152
+	DamageDelay: 517
 	DamageMotion: 828
 	Drops: {
 		Stone_Heart: 6500
@@ -6297,6 +6418,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1180
 	AttackMotion: 480
+	DamageDelay: 180
 	DamageMotion: 648
 	Drops: {
 		Pumpkin_Head: 9000
@@ -6348,6 +6470,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1364
 	AttackMotion: 864
+	DamageDelay: 292
 	DamageMotion: 432
 	Drops: {
 		Zargon: 2000
@@ -6399,6 +6522,7 @@ mob_db: (
 	MoveSpeed: 350
 	AttackDelay: 528
 	AttackMotion: 1000
+	DamageDelay: 225
 	DamageMotion: 396
 	Drops: {
 		Skel_Bone: 8000
@@ -6448,6 +6572,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1028
 	AttackMotion: 528
+	DamageDelay: 225
 	DamageMotion: 360
 	Drops: {
 		Steel: 100
@@ -6496,6 +6621,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1528
 	AttackMotion: 528
+	DamageDelay: 225
 	DamageMotion: 360
 	Drops: {
 		Steel: 100
@@ -6544,6 +6670,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1228
 	AttackMotion: 528
+	DamageDelay: 225
 	DamageMotion: 360
 	Drops: {
 		Boody_Red: 35
@@ -6593,6 +6720,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1528
 	AttackMotion: 528
+	DamageDelay: 270
 	DamageMotion: 360
 	Drops: {
 		Steel: 50
@@ -6642,6 +6770,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1228
 	AttackMotion: 528
+	DamageDelay: 270
 	DamageMotion: 360
 	Drops: {
 		Steel: 40
@@ -6689,6 +6818,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1054
 	AttackMotion: 504
+	DamageDelay: 180
 	DamageMotion: 432
 	Drops: {
 		Old_Frying_Pan: 9000
@@ -6739,6 +6869,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1528
 	AttackMotion: 660
+	DamageDelay: 315
 	DamageMotion: 432
 	Drops: {
 		Yellow_Live: 110
@@ -6788,6 +6919,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1540
 	AttackMotion: 840
+	DamageDelay: 405
 	DamageMotion: 504
 	Drops: {
 		Flame_Heart: 35
@@ -6833,6 +6965,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 2280
 	AttackMotion: 1080
+	DamageDelay: 675
 	DamageMotion: 864
 	Drops: {
 		Single_Cell: 5000
@@ -6873,6 +7006,7 @@ mob_db: (
 	MoveSpeed: 800
 	AttackDelay: 1201
 	AttackMotion: 1
+	DamageDelay: 225
 	DamageMotion: 1
 	Drops: {
 		Tendon: 5000
@@ -6922,6 +7056,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1480
 	AttackMotion: 480
+	DamageDelay: 225
 	DamageMotion: 1056
 	Drops: {
 		Golden_Hair: 9000
@@ -6968,6 +7103,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1956
 	AttackMotion: 756
+	DamageDelay: 438
 	DamageMotion: 528
 	Drops: {
 		Chinese_Ink: 9000
@@ -7013,6 +7149,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1480
 	AttackMotion: 480
+	DamageDelay: 180
 	DamageMotion: 480
 	Drops: {
 		Moustache_Of_Mole: 9000
@@ -7062,6 +7199,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 432
 	AttackMotion: 432
+	DamageDelay: 135
 	DamageMotion: 360
 	Drops: {
 		Matyrs_Flea_Guard: 10
@@ -7114,6 +7252,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 864
 	AttackMotion: 1000
+	DamageDelay: 585
 	DamageMotion: 480
 	DamageTakenRate: 10
 	MvpExp: 89280
@@ -7173,6 +7312,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 1720
 	AttackMotion: 1320
+	DamageDelay: 1012
 	DamageMotion: 360
 	Drops: {
 		Slender_Snake: 5335
@@ -7222,6 +7362,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1360
 	AttackMotion: 960
+	DamageDelay: 540
 	DamageMotion: 432
 	Drops: {
 		Nose_Ring: 5335
@@ -7275,6 +7416,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1276
 	AttackMotion: 576
+	DamageDelay: 112
 	DamageMotion: 288
 	DamageTakenRate: 10
 	MvpExp: 167040
@@ -7333,6 +7475,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1576
 	AttackMotion: 576
+	DamageDelay: 315
 	DamageMotion: 384
 	Drops: {
 		Gas_Mask: 2
@@ -7382,6 +7525,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 2420
 	AttackMotion: 720
+	DamageDelay: 270
 	DamageMotion: 648
 	Drops: {
 		Orcish_Cuspid: 5500
@@ -7430,6 +7574,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 2852
 	AttackMotion: 1152
+	DamageDelay: 720
 	DamageMotion: 840
 	Drops: {
 		Nail_Of_Orc: 5500
@@ -7475,6 +7620,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 976
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Vroken_Sword: 4365
@@ -7523,6 +7669,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 2468
 	AttackMotion: 768
+	DamageDelay: 315
 	DamageMotion: 480
 	Drops: {
 		Dragon_Canine: 5335
@@ -7572,6 +7719,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 315
 	DamageMotion: 288
 	Drops: {
 		Dragon_Scale: 5335
@@ -7625,6 +7773,7 @@ mob_db: (
 	MoveSpeed: 125
 	AttackDelay: 868
 	AttackMotion: 768
+	DamageDelay: 540
 	DamageMotion: 288
 	DamageTakenRate: 10
 	MvpExp: 208800
@@ -7678,6 +7827,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 2544
 	AttackMotion: 1344
+	DamageDelay: 405
 	DamageMotion: 1152
 	Drops: {
 		Fish_Tail: 5500
@@ -7730,6 +7880,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1020
 	AttackMotion: 1020
+	DamageDelay: 303
 	DamageMotion: 288
 	DamageTakenRate: 10
 	MvpExp: 58000
@@ -7784,6 +7935,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 135
 	DamageMotion: 576
 	Drops: {
 		Worm_Peelings: 9000
@@ -7829,6 +7981,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 2208
 	AttackMotion: 1008
+	DamageDelay: 540
 	DamageMotion: 324
 	Drops: {
 		Single_Cell: 9000
@@ -7878,6 +8031,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 512
 	AttackMotion: 528
+	DamageDelay: 405
 	DamageMotion: 240
 	Drops: {
 		Root_Of_Maneater: 5500
@@ -7927,6 +8081,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 824
 	AttackMotion: 780
+	DamageDelay: 360
 	DamageMotion: 420
 	Drops: {
 		Elunium: 106
@@ -7976,6 +8131,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1516
 	AttackMotion: 816
+	DamageDelay: 405
 	DamageMotion: 432
 	Drops: {
 		Old_Blue_Box: 35
@@ -8025,6 +8181,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1672
 	AttackMotion: 720
+	DamageDelay: 630
 	DamageMotion: 288
 	Drops: {
 		Great_Nature: 35
@@ -8071,6 +8228,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1960
 	AttackMotion: 960
+	DamageDelay: 180
 	DamageMotion: 384
 	Drops: {
 		Wild_Boars_Mane: 9000
@@ -8116,6 +8274,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1624
 	AttackMotion: 624
+	DamageDelay: 292
 	DamageMotion: 576
 	Drops: {
 		Animals_Skin: 9000
@@ -8164,6 +8323,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1700
 	AttackMotion: 1000
+	DamageDelay: 360
 	DamageMotion: 500
 	Drops: {
 		Flame_Heart: 45
@@ -8212,6 +8372,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 2420
 	AttackMotion: 720
+	DamageDelay: 405
 	DamageMotion: 384
 	Drops: {
 		Iron: 400
@@ -8259,6 +8420,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 2112
 	AttackMotion: 912
+	DamageDelay: 303
 	DamageMotion: 576
 	Drops: {
 		Long_Hair: 9000
@@ -8450,6 +8612,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1688
 	AttackMotion: 1188
+	DamageDelay: 675
 	DamageMotion: 612
 	Drops: {
 		Wind_Of_Verdure: 70
@@ -8496,6 +8659,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1744
 	AttackMotion: 1044
+	DamageDelay: 236
 	DamageMotion: 684
 	Drops: {
 		Rat_Tail: 9000
@@ -8541,6 +8705,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1768
 	AttackMotion: 768
+	DamageDelay: 540
 	DamageMotion: 384
 	Drops: {
 		Yellow_Live: 90
@@ -8587,6 +8752,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1180
 	AttackMotion: 480
+	DamageDelay: 270
 	DamageMotion: 360
 	Drops: {
 		Tooth_Of_: 5500
@@ -8635,6 +8801,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1780
 	AttackMotion: 1080
+	DamageDelay: 675
 	DamageMotion: 432
 	Drops: {
 		Emveretarcon: 55
@@ -8685,6 +8852,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1960
 	AttackMotion: 960
+	DamageDelay: 675
 	DamageMotion: 504
 	Drops: {
 		Sparkling_Dust: 150
@@ -8733,6 +8901,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 840
 	AttackMotion: 540
+	DamageDelay: 337
 	DamageMotion: 480
 	Drops: {
 		Fox_Tail: 4656
@@ -8864,6 +9033,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1076
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Iron: 50
@@ -8913,6 +9083,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1672
 	AttackMotion: 672
+	DamageDelay: 180
 	DamageMotion: 480
 	Drops: {
 		Fluff: 2000
@@ -8953,6 +9124,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1960
 	AttackMotion: 960
+	DamageDelay: 675
 	DamageMotion: 504
 	Drops: {
 		Sparkling_Dust: 10
@@ -9000,6 +9172,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 2536
 	AttackMotion: 1536
+	DamageDelay: 1440
 	DamageMotion: 672
 	Drops: {
 		Sparkling_Dust: 150
@@ -9046,6 +9219,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1720
 	AttackMotion: 500
+	DamageDelay: 1080
 	DamageMotion: 420
 	Drops: {
 		Short_Daenggie: 5500
@@ -9095,6 +9269,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1960
 	AttackMotion: 620
+	DamageDelay: 810
 	DamageMotion: 480
 	Drops: {
 		Sharpened_Cuspid: 4656
@@ -9148,6 +9323,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1248
 	AttackMotion: 500
+	DamageDelay: 585
 	DamageMotion: 360
 	DamageTakenRate: 10
 	MvpExp: 31102
@@ -9203,6 +9379,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 972
 	AttackMotion: 500
+	DamageDelay: 450
 	DamageMotion: 288
 	Drops: {
 		Old_Violet_Box: 5
@@ -9254,6 +9431,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1816
 	AttackMotion: 576
+	DamageDelay: 360
 	DamageMotion: 240
 	Drops: {
 		Transparent_Cloth: 5820
@@ -9305,6 +9483,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1020
 	AttackMotion: 500
+	DamageDelay: 506
 	DamageMotion: 768
 	Drops: {
 		Needle_Of_Alarm: 5335
@@ -9356,6 +9535,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 960
 	AttackMotion: 500
+	DamageDelay: 450
 	DamageMotion: 480
 	Drops: {
 		Round_Shell: 3500
@@ -9407,6 +9587,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 864
 	AttackMotion: 500
+	DamageDelay: 438
 	DamageMotion: 192
 	Drops: {
 		Worn_Out_Page: 4850
@@ -9456,6 +9637,7 @@ mob_db: (
 	MoveSpeed: 350
 	AttackDelay: 1848
 	AttackMotion: 500
+	DamageDelay: 810
 	DamageMotion: 576
 	Drops: {
 		Manacles: 3500
@@ -9505,6 +9687,7 @@ mob_db: (
 	MoveSpeed: 350
 	AttackDelay: 1768
 	AttackMotion: 500
+	DamageDelay: 450
 	DamageMotion: 192
 	Drops: {
 		Worn_Out_Prison_Uniform: 3500
@@ -9556,6 +9739,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 864
 	AttackMotion: 1252
+	DamageDelay: 360
 	DamageMotion: 476
 	Drops: {
 		Book_Of_The_Apocalypse: 5
@@ -9605,6 +9789,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1500
 	AttackMotion: 500
+	DamageDelay: 1080
 	DamageMotion: 1000
 	Drops: {
 		Mould_Powder: 5335
@@ -9655,6 +9840,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 800
 	AttackMotion: 2112
+	DamageDelay: 1980
 	DamageMotion: 768
 	Drops: {
 		Executioners_Mitten: 5
@@ -9705,6 +9891,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1790
 	AttackMotion: 1440
+	DamageDelay: 843
 	DamageMotion: 540
 	Drops: {
 		Thin_N_Long_Tongue: 3880
@@ -9754,6 +9941,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 1744
 	AttackMotion: 1344
+	DamageDelay: 900
 	DamageMotion: 600
 	Drops: {
 		Thin_N_Long_Tongue: 3880
@@ -9806,6 +9994,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1152
 	AttackMotion: 500
+	DamageDelay: 720
 	DamageMotion: 240
 	Drops: {
 		Lokis_Whispers: 1
@@ -9860,6 +10049,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 816
 	AttackMotion: 500
+	DamageDelay: 540
 	DamageMotion: 240
 	Drops: {
 		Old_Hilt: 1
@@ -9913,6 +10103,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 768
 	AttackMotion: 500
+	DamageDelay: 450
 	DamageMotion: 384
 	Drops: {
 		Bloody_Edge: 5
@@ -9964,6 +10155,7 @@ mob_db: (
 	MoveSpeed: 190
 	AttackDelay: 900
 	AttackMotion: 500
+	DamageDelay: 618
 	DamageMotion: 864
 	Drops: {
 		Anolian_Skin: 4850
@@ -10015,6 +10207,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 528
 	AttackMotion: 500
+	DamageDelay: 315
 	DamageMotion: 240
 	Drops: {
 		Mud_Lump: 4850
@@ -10068,6 +10261,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 672
 	AttackMotion: 500
+	DamageDelay: 630
 	DamageMotion: 192
 	Drops: {
 		Skull: 4850
@@ -10117,6 +10311,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1000
 	AttackMotion: 500
+	DamageDelay: 607
 	DamageMotion: 1000
 	Drops: {
 		Claw_Of_Rat: 4656
@@ -10216,6 +10411,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1500
 	AttackMotion: 500
+	DamageDelay: 675
 	DamageMotion: 1000
 	Drops: {
 		Glitter_Shell: 5335
@@ -10266,6 +10462,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1500
 	AttackMotion: 500
+	DamageDelay: 360
 	DamageMotion: 1000
 	Drops: {
 		Tail_Of_Steel_Scorpion: 5335
@@ -10316,6 +10513,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1500
 	AttackMotion: 500
+	DamageDelay: 405
 	DamageMotion: 1000
 	Drops: {
 		Ogre_Tooth: 2500
@@ -10365,6 +10563,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1028
 	AttackMotion: 528
+	DamageDelay: 472
 	DamageMotion: 360
 	Drops: {
 		Claw_Of_Monkey: 5335
@@ -10414,6 +10613,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1956
 	AttackMotion: 756
+	DamageDelay: 270
 	DamageMotion: 528
 	Drops: {
 		Tough_Scalelike_Stem: 5335
@@ -10465,6 +10665,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 832
 	AttackMotion: 500
+	DamageDelay: 315
 	DamageMotion: 600
 	Drops: {
 		Coral_Reef: 4850
@@ -10517,6 +10718,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1500
 	AttackMotion: 500
+	DamageDelay: 675
 	DamageMotion: 1000
 	Drops: {
 		Reins: 5335
@@ -11603,6 +11805,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Garlet: 3200
@@ -11654,6 +11857,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1260
 	AttackMotion: 192
+	DamageDelay: 1181
 	DamageMotion: 192
 	Drops: {
 		Zargon: 750
@@ -11699,6 +11903,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1180
 	AttackMotion: 480
+	DamageDelay: 180
 	DamageMotion: 648
 	Drops: {
 		Pumpkin_Head: 5335
@@ -11744,6 +11949,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1120
 	AttackMotion: 620
+	DamageDelay: 360
 	DamageMotion: 240
 	Drops: {
 		Packing_Ribbon: 550
@@ -11790,6 +11996,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1248
 	AttackMotion: 1248
+	DamageDelay: 315
 	DamageMotion: 240
 	Drops: {
 		Well_Baked_Cookie: 1500
@@ -11836,6 +12043,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 720
 	AttackMotion: 720
+	DamageDelay: 405
 	DamageMotion: 432
 	Drops: {
 		Red_Socks_With_Holes: 10000
@@ -11883,6 +12091,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1296
 	AttackMotion: 1296
+	DamageDelay: 1215
 	DamageMotion: 432
 	Drops: {
 		Manacles: 900
@@ -11929,6 +12138,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1248
 	AttackMotion: 1248
+	DamageDelay: 405
 	DamageMotion: 432
 	Drops: {
 		Candy_Striper: 90
@@ -11980,6 +12190,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 672
 	AttackMotion: 672
+	DamageDelay: 315
 	DamageMotion: 288
 	Drops: {
 		Matchstick: 2500
@@ -12034,6 +12245,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 468
 	AttackMotion: 468
+	DamageDelay: 236
 	DamageMotion: 288
 	DamageTakenRate: 10
 	MvpExp: 206900
@@ -12095,6 +12307,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 608
 	AttackMotion: 408
+	DamageDelay: 292
 	DamageMotion: 336
 	DamageTakenRate: 10
 	MvpExp: 379440
@@ -12150,6 +12363,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1020
 	AttackMotion: 720
+	DamageDelay: 562
 	DamageMotion: 384
 	Drops: {
 		Zargon: 3880
@@ -12200,6 +12414,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1000
 	AttackMotion: 900
+	DamageDelay: 236
 	DamageMotion: 384
 	Drops: {
 		Cyfar: 3000
@@ -12252,6 +12467,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 776
 	AttackMotion: 576
+	DamageDelay: 360
 	DamageMotion: 288
 	Drops: {
 		Earthworm_Peeling: 5100
@@ -12303,6 +12519,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 700
 	AttackMotion: 648
+	DamageDelay: 371
 	DamageMotion: 480
 	Drops: {
 		Earthworm_Peeling: 5500
@@ -12353,6 +12570,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 770
 	AttackMotion: 720
+	DamageDelay: 506
 	DamageMotion: 336
 	Drops: {
 		Steel: 300
@@ -12400,6 +12618,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1172
 	AttackMotion: 672
+	DamageDelay: 495
 	DamageMotion: 420
 	Drops: {
 		Goblini_Mask: 3
@@ -12453,6 +12672,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 704
 	AttackMotion: 504
+	DamageDelay: 270
 	DamageMotion: 432
 	Drops: {
 		Talon_Of_Griffin: 2500
@@ -12505,6 +12725,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 920
 	AttackMotion: 720
+	DamageDelay: 337
 	DamageMotion: 200
 	Drops: {
 		Brigan: 4656
@@ -12549,6 +12770,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 964
 	AttackMotion: 864
+	DamageDelay: 787
 	DamageMotion: 288
 	Drops: {
 		Cyfar: 5335
@@ -12603,6 +12825,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1280
 	AttackMotion: 1080
+	DamageDelay: 843
 	DamageMotion: 240
 	Drops: {
 		Brigan: 4850
@@ -12655,6 +12878,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1056
 	AttackMotion: 1056
+	DamageDelay: 675
 	DamageMotion: 336
 	Drops: {
 		Zargon: 4559
@@ -12706,6 +12930,7 @@ mob_db: (
 	MoveSpeed: 220
 	AttackDelay: 916
 	AttackMotion: 816
+	DamageDelay: 360
 	DamageMotion: 336
 	Drops: {
 		Lip_Of_Ancient_Fish: 1300
@@ -12753,6 +12978,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1036
 	AttackMotion: 936
+	DamageDelay: 101
 	DamageMotion: 240
 	Drops: {
 		Well_Baked_Cookie: 1000
@@ -12799,6 +13025,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1264
 	AttackMotion: 864
+	DamageDelay: 315
 	DamageMotion: 216
 	Drops: {
 		Sticky_Mucus: 500
@@ -12850,6 +13077,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1078
 	AttackMotion: 768
+	DamageDelay: 540
 	DamageMotion: 384
 	Drops: {
 		Brigan: 3200
@@ -12899,6 +13127,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 828
 	AttackMotion: 528
+	DamageDelay: 270
 	DamageMotion: 192
 	Drops: {
 		Brigan: 4850
@@ -12945,6 +13174,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1092
 	AttackMotion: 792
+	DamageDelay: 405
 	DamageMotion: 480
 	Drops: {
 		Needle_Of_Alarm: 5335
@@ -12992,6 +13222,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1072
 	AttackMotion: 672
+	DamageDelay: 360
 	DamageMotion: 384
 	Drops: {
 		Needle_Of_Alarm: 5335
@@ -13038,6 +13269,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1100
 	AttackMotion: 900
+	DamageDelay: 506
 	DamageMotion: 480
 	Drops: {
 		Zargon: 1000
@@ -13089,6 +13321,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 868
 	AttackMotion: 768
+	DamageDelay: 382
 	DamageMotion: 480
 	DamageTakenRate: 10
 	MvpExp: 357120
@@ -13147,6 +13380,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1050
 	AttackMotion: 900
+	DamageDelay: 506
 	DamageMotion: 288
 	Drops: {
 		Cyfar: 4656
@@ -13192,6 +13426,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1332
 	AttackMotion: 1332
+	DamageDelay: 877
 	DamageMotion: 672
 	Drops: {
 		Zargon: 100
@@ -13236,6 +13471,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 502
 	AttackMotion: 1999
+	DamageDelay: 2160
 	DamageMotion: 480
 	Drops: {
 		Alices_Apron: 2500
@@ -13284,6 +13520,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1152
 	AttackMotion: 1152
+	DamageDelay: 911
 	DamageMotion: 480
 	Drops: {
 		Brigan: 4656
@@ -13328,6 +13565,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1152
 	AttackMotion: 1152
+	DamageDelay: 765
 	DamageMotion: 384
 	Drops: {
 		Brigan: 2000
@@ -13374,6 +13612,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1264
 	AttackMotion: 864
+	DamageDelay: 810
 	DamageMotion: 288
 	Drops: {
 		Mud_Lump: 2000
@@ -13426,6 +13665,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 860
 	AttackMotion: 660
+	DamageDelay: 618
 	DamageMotion: 624
 	Drops: {
 		Cyfar: 100
@@ -13472,6 +13712,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1008
 	AttackMotion: 1008
+	DamageDelay: 303
 	DamageMotion: 528
 	Drops: {
 		Scell: 2500
@@ -13518,6 +13759,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 936
 	AttackMotion: 936
+	DamageDelay: 472
 	DamageMotion: 288
 	Drops: {
 		Librarian_Glove: 5
@@ -13565,6 +13807,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1008
 	AttackMotion: 1008
+	DamageDelay: 472
 	DamageMotion: 384
 	Drops: {
 		Zargon: 250
@@ -13618,6 +13861,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 772
 	AttackMotion: 672
+	DamageDelay: 360
 	DamageMotion: 360
 	Drops: {
 		Brigan: 5335
@@ -13878,6 +14122,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1024
 	AttackMotion: 1000
+	DamageDelay: 585
 	DamageMotion: 480
 	Drops: {
 		Cyfar: 4413
@@ -13929,6 +14174,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 2276
 	AttackMotion: 576
+	DamageDelay: 202
 	DamageMotion: 432
 	Drops: {
 		Burn_Tree: 2550
@@ -13980,6 +14226,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 1816
 	AttackMotion: 576
+	DamageDelay: 765
 	DamageMotion: 240
 	Drops: {
 		Transparent_Cloth: 4413
@@ -14032,6 +14279,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1000
 	AttackMotion: 600
+	DamageDelay: 1800
 	DamageMotion: 384
 	Drops: {
 		Petite_DiablOfs_Horn: 4413
@@ -14084,6 +14332,7 @@ mob_db: (
 	MoveSpeed: 155
 	AttackDelay: 1136
 	AttackMotion: 720
+	DamageDelay: 405
 	DamageMotion: 840
 	Drops: {
 		Powder_Of_Butterfly: 4550
@@ -14136,6 +14385,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 1528
 	AttackMotion: 660
+	DamageDelay: 225
 	DamageMotion: 432
 	Drops: {
 		Limb_Of_Mantis: 4550
@@ -14189,6 +14439,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 1345
 	AttackMotion: 824
+	DamageDelay: 2340
 	DamageMotion: 440
 	Drops: {
 		Tatters_Clothes: 3500
@@ -14240,6 +14491,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1028
 	AttackMotion: 528
+	DamageDelay: 225
 	DamageMotion: 360
 	Drops: {
 		Steel: 450
@@ -14291,6 +14543,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 1772
 	AttackMotion: 120
+	DamageDelay: 270
 	DamageMotion: 384
 	Drops: {
 		Rotten_Bandage: 4413
@@ -14342,6 +14595,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 2612
 	AttackMotion: 912
+	DamageDelay: 855
 	DamageMotion: 288
 	Drops: {
 		Tatters_Clothes: 4413
@@ -14393,6 +14647,7 @@ mob_db: (
 	MoveSpeed: 120
 	AttackDelay: 1120
 	AttackMotion: 620
+	DamageDelay: 1170
 	DamageMotion: 240
 	Drops: {
 		Brigan: 1500
@@ -14445,6 +14700,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1672
 	AttackMotion: 672
+	DamageDelay: 180
 	DamageMotion: 480
 	Drops: {
 		Feather: 3000
@@ -14497,6 +14753,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1156
 	AttackMotion: 456
+	DamageDelay: 270
 	DamageMotion: 384
 	Drops: {
 		Dokkaebi_Horn: 4550
@@ -14550,6 +14807,7 @@ mob_db: (
 	MoveSpeed: 145
 	AttackDelay: 1024
 	AttackMotion: 768
+	DamageDelay: 5130
 	DamageMotion: 480
 	Drops: {
 		Bone_Wand: 3
@@ -14602,6 +14860,7 @@ mob_db: (
 	MoveSpeed: 155
 	AttackDelay: 1292
 	AttackMotion: 792
+	DamageDelay: 742
 	DamageMotion: 340
 	Drops: {
 		Royal_Jelly: 550
@@ -14654,6 +14913,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1468
 	AttackMotion: 468
+	DamageDelay: 202
 	DamageMotion: 768
 	Drops: {
 		Spiderweb: 4550
@@ -14706,6 +14966,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1792
 	AttackMotion: 792
+	DamageDelay: 540
 	DamageMotion: 336
 	Drops: {
 		Short_Leg: 4413
@@ -14757,6 +15018,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 1260
 	AttackMotion: 230
+	DamageDelay: 1260
 	DamageMotion: 192
 	Drops: {
 		Bears_Foot: 4550
@@ -14810,6 +15072,7 @@ mob_db: (
 	MoveSpeed: 155
 	AttackDelay: 1276
 	AttackMotion: 576
+	DamageDelay: 112
 	DamageMotion: 288
 	Drops: {
 		Puppy_Love: 1
@@ -14861,6 +15124,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 960
 	AttackMotion: 1008
+	DamageDelay: 2520
 	DamageMotion: 840
 	Drops: {
 		Cyfar: 4413
@@ -14912,6 +15176,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1000
 	AttackMotion: 1152
+	DamageDelay: 517
 	DamageMotion: 828
 	Drops: {
 		Stone_Heart: 6500
@@ -14963,6 +15228,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1100
 	AttackMotion: 960
+	DamageDelay: 1800
 	DamageMotion: 780
 	Drops: {
 		Nose_Ring: 4413
@@ -15014,6 +15280,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1960
 	AttackMotion: 960
+	DamageDelay: 180
 	DamageMotion: 384
 	Drops: {
 		Wild_Boars_Mane: 3500
@@ -15068,6 +15335,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 900
 	AttackMotion: 1000
+	DamageDelay: 585
 	DamageMotion: 500
 	DamageTakenRate: 10
 	MvpExp: 466560
@@ -15126,6 +15394,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1100
 	AttackMotion: 560
+	DamageDelay: 630
 	DamageMotion: 580
 	Drops: {
 		Poison_Knife: 3
@@ -15172,6 +15441,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1100
 	AttackMotion: 483
+	DamageDelay: 675
 	DamageMotion: 528
 	Drops: {
 		Turtle_Shell: 4413
@@ -15223,6 +15493,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 512
 	AttackMotion: 780
+	DamageDelay: 506
 	DamageMotion: 504
 	Drops: {
 		Turtle_Shell: 4413
@@ -15269,6 +15540,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1452
 	AttackMotion: 483
+	DamageDelay: 1350
 	DamageMotion: 528
 	Drops: {
 		Turtle_Shell: 4413
@@ -15319,6 +15591,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1612
 	AttackMotion: 622
+	DamageDelay: 540
 	DamageMotion: 583
 	Drops: {
 		Zargon: 4365
@@ -15370,6 +15643,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1452
 	AttackMotion: 483
+	DamageDelay: 1215
 	DamageMotion: 528
 	Drops: {
 		Turtle_Shell: 4413
@@ -15421,6 +15695,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 1260
 	AttackMotion: 960
+	DamageDelay: 506
 	DamageMotion: 672
 	Drops: {
 		Turtle_Shell: 4413
@@ -15474,6 +15749,7 @@ mob_db: (
 	MoveSpeed: 195
 	AttackDelay: 1345
 	AttackMotion: 824
+	DamageDelay: 720
 	DamageMotion: 440
 	Drops: {
 		Tatters_Clothes: 4413
@@ -15526,6 +15802,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 862
 	AttackMotion: 534
+	DamageDelay: 337
 	DamageMotion: 312
 	Drops: {
 		Dragon_Fly_Wing: 4413
@@ -15572,6 +15849,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 1120
 	AttackMotion: 552
+	DamageDelay: 708
 	DamageMotion: 0
 	Drops: {
 		Brigan: 3500
@@ -15621,6 +15899,7 @@ mob_db: (
 	MoveSpeed: 190
 	AttackDelay: 1132
 	AttackMotion: 583
+	DamageDelay: 405
 	DamageMotion: 532
 	Drops: {
 		Scarlet_Jewel: 150
@@ -17475,6 +17754,7 @@ mob_db: (
 	MoveSpeed: 155
 	AttackDelay: 1000
 	AttackMotion: 900
+	DamageDelay: 1350
 	DamageMotion: 432
 	Drops: {
 		Wooden_Block: 9000
@@ -17514,6 +17794,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1840
 	AttackMotion: 1440
+	DamageDelay: 675
 	DamageMotion: 384
 	Drops: {
 		Broken_Steel_Piece: 5335
@@ -17563,6 +17844,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 2190
 	AttackMotion: 2040
+	DamageDelay: 675
 	DamageMotion: 336
 	Drops: {
 		Cold_Magma: 4559
@@ -17614,6 +17896,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 1732
 	AttackMotion: 1332
+	DamageDelay: 438
 	DamageMotion: 540
 	Drops: {
 		Burning_Heart: 4850
@@ -17655,6 +17938,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 1308
 	AttackMotion: 1008
+	DamageDelay: 450
 	DamageMotion: 480
 	Drops: {
 		Blossom_Of_Maneater: 6200
@@ -17700,6 +17984,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1460
 	AttackMotion: 960
+	DamageDelay: 2340
 	DamageMotion: 432
 	Drops: {
 		Peco_Wing_Feather: 4850
@@ -17750,6 +18035,7 @@ mob_db: (
 	MoveSpeed: 155
 	AttackDelay: 1306
 	AttackMotion: 1056
+	DamageDelay: 540
 	DamageMotion: 288
 	Drops: {
 		Fruit_Of_Mastela: 1500
@@ -17800,6 +18086,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 920
 	AttackMotion: 720
+	DamageDelay: 393
 	DamageMotion: 336
 	Drops: {
 		Blue_Gemstone: 1000
@@ -17845,6 +18132,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1380
 	AttackMotion: 1080
+	DamageDelay: 675
 	DamageMotion: 336
 	Drops: {
 		Goats_Horn: 4559
@@ -17899,6 +18187,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 1446
 	AttackMotion: 1296
+	DamageDelay: 720
 	DamageMotion: 360
 	DamageTakenRate: 10
 	MvpExp: 218560
@@ -17958,6 +18247,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 850
 	AttackMotion: 600
+	DamageDelay: 393
 	DamageMotion: 336
 	Drops: {
 		Fruit_Of_Mastela: 1500
@@ -18007,6 +18297,7 @@ mob_db: (
 	MoveSpeed: 350
 	AttackDelay: 720
 	AttackMotion: 864
+	DamageDelay: 506
 	DamageMotion: 504
 	Drops: {
 		Smooth_Paper: 4947
@@ -18055,6 +18346,7 @@ mob_db: (
 	MoveSpeed: 155
 	AttackDelay: 972
 	AttackMotion: 672
+	DamageDelay: 360
 	DamageMotion: 470
 	Drops: {
 		Harpys_Feather: 4850
@@ -18103,6 +18395,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1552
 	AttackMotion: 1152
+	DamageDelay: 675
 	DamageMotion: 336
 	Drops: {
 		Old_Magic_Circle: 4000
@@ -18153,6 +18446,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 1260
 	AttackMotion: 960
+	DamageDelay: 630
 	DamageMotion: 672
 	Drops: {
 		Spawns: 4074
@@ -18200,6 +18494,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1216
 	AttackMotion: 816
+	DamageDelay: 765
 	DamageMotion: 432
 	Drops: {
 		Burning_Horse_Shoe: 4947
@@ -18249,6 +18544,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1300
 	AttackMotion: 900
+	DamageDelay: 506
 	DamageMotion: 336
 	Drops: {
 		Lizard_Scruff: 7500
@@ -18294,6 +18590,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1492
 	AttackMotion: 1092
+	DamageDelay: 787
 	DamageMotion: 192
 	Drops: {
 		Bears_Foot: 5000
@@ -18341,6 +18638,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1080
 	AttackMotion: 780
+	DamageDelay: 810
 	DamageMotion: 180
 	Drops: {
 		Petite_DiablOfs_Horn: 5820
@@ -18388,6 +18686,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1260
 	AttackMotion: 960
+	DamageDelay: 450
 	DamageMotion: 336
 	Drops: {
 		Wing_Of_Red_Bat: 5500
@@ -18435,6 +18734,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 1020
 	AttackMotion: 720
+	DamageDelay: 315
 	DamageMotion: 384
 	Drops: {
 		Dragons_Skin: 4074
@@ -18481,6 +18781,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 1024
 	AttackMotion: 624
+	DamageDelay: 315
 	DamageMotion: 336
 	Drops: {
 		Dragons_Skin: 4074
@@ -18528,6 +18829,7 @@ mob_db: (
 	MoveSpeed: 195
 	AttackDelay: 1350
 	AttackMotion: 1200
+	DamageDelay: 675
 	DamageMotion: 432
 	Drops: {
 		Sand_Lump: 4947
@@ -18577,6 +18879,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 1264
 	AttackMotion: 864
+	DamageDelay: 360
 	DamageMotion: 576
 	Drops: {
 		Scropions_Nipper: 4365
@@ -18629,6 +18932,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 1072
 	AttackMotion: 672
+	DamageDelay: 292
 	DamageMotion: 480
 	Drops: {
 		Satanic_Chain: 5
@@ -18682,6 +18986,7 @@ mob_db: (
 	MoveSpeed: 145
 	AttackDelay: 1290
 	AttackMotion: 1140
+	DamageDelay: 731
 	DamageMotion: 576
 	DamageTakenRate: 10
 	MvpExp: 156240
@@ -18735,6 +19040,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 1356
 	AttackMotion: 1056
+	DamageDelay: 225
 	DamageMotion: 540
 	Drops: {
 		Golden_Hair: 6305
@@ -18783,6 +19089,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1430
 	AttackMotion: 1080
+	DamageDelay: 450
 	DamageMotion: 1080
 	Drops: {
 		Cyfar: 5335
@@ -18830,6 +19137,7 @@ mob_db: (
 	MoveSpeed: 155
 	AttackDelay: 2416
 	AttackMotion: 2016
+	DamageDelay: 945
 	DamageMotion: 432
 	Drops: {
 		Large_Jellopy: 500
@@ -18879,6 +19187,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1772
 	AttackMotion: 72
+	DamageDelay: 270
 	DamageMotion: 384
 },
 {
@@ -18918,6 +19227,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 2612
 	AttackMotion: 912
+	DamageDelay: 855
 	DamageMotion: 288
 },
 {
@@ -18955,6 +19265,7 @@ mob_db: (
 	MoveSpeed: 190
 	AttackDelay: 0
 	AttackMotion: 0
+	DamageDelay: 1080
 	DamageMotion: 0
 	Drops: {
 		Piece_Of_Cake: 3800
@@ -19002,6 +19313,7 @@ mob_db: (
 	MoveSpeed: 190
 	AttackDelay: 0
 	AttackMotion: 0
+	DamageDelay: 1080
 	DamageMotion: 0
 	Drops: {
 		Piece_Of_Cake: 3800
@@ -19048,6 +19360,7 @@ mob_db: (
 	MoveSpeed: 190
 	AttackDelay: 0
 	AttackMotion: 0
+	DamageDelay: 1080
 	DamageMotion: 0
 	Drops: {
 		Piece_Of_Cake: 3800
@@ -19094,6 +19407,7 @@ mob_db: (
 	MoveSpeed: 190
 	AttackDelay: 0
 	AttackMotion: 0
+	DamageDelay: 1080
 	DamageMotion: 0
 	Drops: {
 		Piece_Of_Cake: 3800
@@ -19147,6 +19461,7 @@ mob_db: (
 	MoveSpeed: 130
 	AttackDelay: 768
 	AttackMotion: 768
+	DamageDelay: 360
 	DamageMotion: 576
 	MvpExp: 130875
 	MvpDrops: {
@@ -19199,6 +19514,7 @@ mob_db: (
 	MoveSpeed: 155
 	AttackDelay: 1638
 	AttackMotion: 2016
+	DamageDelay: 405
 	DamageMotion: 576
 	Drops: {
 		Oil_Paper: 5000
@@ -19250,6 +19566,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1003
 	AttackMotion: 1152
+	DamageDelay: 2160
 	DamageMotion: 336
 	Drops: {
 		Broken_Shuriken: 5335
@@ -19296,6 +19613,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 1148
 	AttackMotion: 1728
+	DamageDelay: 585
 	DamageMotion: 864
 	Drops: {
 		Poison_Toads_Skin: 5500
@@ -19344,6 +19662,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 1084
 	AttackMotion: 2304
+	DamageDelay: 450
 	DamageMotion: 576
 	Drops: {
 		Iron: 5500
@@ -19392,6 +19711,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1938
 	AttackMotion: 2112
+	DamageDelay: 1980
 	DamageMotion: 768
 	Drops: {
 		Glossy_Hair: 5335
@@ -19442,6 +19762,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1439
 	AttackMotion: 1920
+	DamageDelay: 585
 	DamageMotion: 672
 	Drops: {
 		Tengus_Nose: 3500
@@ -19491,6 +19812,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 2012
 	AttackMotion: 1728
+	DamageDelay: 540
 	DamageMotion: 672
 	Drops: {
 		Yellow_Plate: 6500
@@ -19573,6 +19895,7 @@ mob_db: (
 	MoveSpeed: 145
 	AttackDelay: 472
 	AttackMotion: 576
+	DamageDelay: 450
 	DamageMotion: 288
 	Drops: {
 		Sharp_Feeler: 4608
@@ -19619,6 +19942,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 1247
 	AttackMotion: 768
+	DamageDelay: 315
 	DamageMotion: 420
 	Drops: {
 		Bamboo_Cut: 3200
@@ -19666,6 +19990,7 @@ mob_db: (
 	MoveSpeed: 410
 	AttackDelay: 400
 	AttackMotion: 672
+	DamageDelay: 630
 	DamageMotion: 480
 	Drops: {
 		Hard_Peach: 4365
@@ -19706,6 +20031,7 @@ mob_db: (
 	MoveSpeed: 0
 	AttackDelay: 0
 	AttackMotion: 0
+	DamageDelay: 0
 	DamageMotion: 0
 },
 {
@@ -19744,6 +20070,7 @@ mob_db: (
 	MoveSpeed: 190
 	AttackDelay: 480
 	AttackMotion: 840
+	DamageDelay: 585
 	DamageMotion: 432
 	Drops: {
 		Cloud_Piece: 4656
@@ -19791,6 +20118,7 @@ mob_db: (
 	MoveSpeed: 140
 	AttackDelay: 512
 	AttackMotion: 756
+	DamageDelay: 506
 	DamageMotion: 360
 	Drops: {
 		Leaflet_Of_Hinal: 3500
@@ -19832,6 +20160,7 @@ mob_db: (
 	MoveSpeed: 0
 	AttackDelay: 0
 	AttackMotion: 0
+	DamageDelay: 0
 	DamageMotion: 0
 },
 {
@@ -19871,6 +20200,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 318
 	AttackMotion: 528
+	DamageDelay: 225
 	DamageMotion: 420
 	Drops: {
 		Leopard_Skin: 5200
@@ -19923,6 +20253,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 637
 	AttackMotion: 1008
+	DamageDelay: 540
 	DamageMotion: 360
 	Drops: {
 		Limpid_Celestial_Robe: 3977
@@ -19969,6 +20300,7 @@ mob_db: (
 	MoveSpeed: 155
 	AttackDelay: 780
 	AttackMotion: 1008
+	DamageDelay: 270
 	DamageMotion: 420
 	Drops: {
 		Black_Bears_Skin: 4462
@@ -20020,6 +20352,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 588
 	AttackMotion: 816
+	DamageDelay: 1530
 	DamageMotion: 420
 	DamageTakenRate: 10
 	MvpExp: 78120
@@ -20076,6 +20409,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1276
 	AttackMotion: 576
+	DamageDelay: 540
 	DamageMotion: 384
 },
 {
@@ -20115,6 +20449,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 2864
 	AttackMotion: 864
+	DamageDelay: 630
 	DamageMotion: 576
 },
 {
@@ -20155,6 +20490,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1384
 	AttackMotion: 768
+	DamageDelay: 450
 	DamageMotion: 336
 },
 {
@@ -20195,6 +20531,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 676
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 480
 },
 {
@@ -20234,6 +20571,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 2456
 	AttackMotion: 912
+	DamageDelay: 427
 	DamageMotion: 504
 },
 {
@@ -20273,6 +20611,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1576
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 576
 },
 {
@@ -20312,6 +20651,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 360
 	DamageMotion: 288
 },
 {
@@ -20351,6 +20691,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1272
 	AttackMotion: 72
+	DamageDelay: 202
 	DamageMotion: 480
 },
 {
@@ -20391,6 +20732,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1816
 	AttackMotion: 816
+	DamageDelay: 765
 	DamageMotion: 432
 },
 {
@@ -20430,6 +20772,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1672
 	AttackMotion: 672
+	DamageDelay: 630
 	DamageMotion: 288
 },
 {
@@ -20470,6 +20813,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1792
 	AttackMotion: 792
+	DamageDelay: 540
 	DamageMotion: 336
 },
 {
@@ -20510,6 +20854,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1468
 	AttackMotion: 468
+	DamageDelay: 202
 	DamageMotion: 768
 },
 {
@@ -20550,6 +20895,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 868
 	AttackMotion: 480
+	DamageDelay: 540
 	DamageMotion: 120
 },
 {
@@ -20589,6 +20935,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1120
 	AttackMotion: 420
+	DamageDelay: 168
 	DamageMotion: 288
 },
 {
@@ -20629,6 +20976,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 980
 	AttackMotion: 600
+	DamageDelay: 270
 	DamageMotion: 384
 },
 {
@@ -20668,6 +21016,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1276
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 384
 },
 {
@@ -20707,6 +21056,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 2276
 	AttackMotion: 576
+	DamageDelay: 157
 	DamageMotion: 336
 },
 {
@@ -20746,6 +21096,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1180
 	AttackMotion: 480
+	DamageDelay: 180
 	DamageMotion: 648
 },
 {
@@ -20785,6 +21136,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1364
 	AttackMotion: 864
+	DamageDelay: 292
 	DamageMotion: 432
 },
 {
@@ -20824,6 +21176,7 @@ mob_db: (
 	MoveSpeed: 350
 	AttackDelay: 528
 	AttackMotion: 1000
+	DamageDelay: 225
 	DamageMotion: 396
 },
 {
@@ -20863,6 +21216,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1500
 	AttackMotion: 500
+	DamageDelay: 405
 	DamageMotion: 1000
 },
 {
@@ -20902,6 +21256,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1500
 	AttackMotion: 500
+	DamageDelay: 270
 	DamageMotion: 1000
 },
 {
@@ -20941,6 +21296,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 832
 	AttackMotion: 500
+	DamageDelay: 315
 	DamageMotion: 600
 },
 {
@@ -20980,6 +21336,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1260
 	AttackMotion: 192
+	DamageDelay: 1181
 	DamageMotion: 192
 },
 {
@@ -21019,6 +21376,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1296
 	AttackMotion: 1296
+	DamageDelay: 1215
 	DamageMotion: 432
 	Drops: {
 		Undelivered_Gift: 10000
@@ -21061,6 +21419,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 672
 	AttackMotion: 672
+	DamageDelay: 315
 	DamageMotion: 288
 },
 {
@@ -21100,6 +21459,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1000
 	AttackMotion: 900
+	DamageDelay: 236
 	DamageMotion: 384
 },
 {
@@ -21139,6 +21499,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 770
 	AttackMotion: 720
+	DamageDelay: 506
 	DamageMotion: 336
 },
 {
@@ -21180,6 +21541,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 704
 	AttackMotion: 504
+	DamageDelay: 270
 	DamageMotion: 432
 },
 {
@@ -21220,6 +21582,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 920
 	AttackMotion: 720
+	DamageDelay: 337
 	DamageMotion: 200
 },
 {
@@ -21262,6 +21625,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1280
 	AttackMotion: 1080
+	DamageDelay: 843
 	DamageMotion: 240
 },
 {
@@ -21302,6 +21666,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1056
 	AttackMotion: 1056
+	DamageDelay: 675
 	DamageMotion: 336
 },
 {
@@ -21341,6 +21706,7 @@ mob_db: (
 	MoveSpeed: 220
 	AttackDelay: 916
 	AttackMotion: 816
+	DamageDelay: 360
 	DamageMotion: 336
 },
 {
@@ -21380,6 +21746,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1050
 	AttackMotion: 900
+	DamageDelay: 506
 	DamageMotion: 288
 },
 {
@@ -21420,6 +21787,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1152
 	AttackMotion: 1152
+	DamageDelay: 911
 	DamageMotion: 480
 },
 {
@@ -21460,6 +21828,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 860
 	AttackMotion: 660
+	DamageDelay: 618
 	DamageMotion: 624
 },
 {
@@ -21499,6 +21868,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1008
 	AttackMotion: 1008
+	DamageDelay: 472
 	DamageMotion: 384
 },
 {
@@ -21540,6 +21910,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 772
 	AttackMotion: 672
+	DamageDelay: 360
 	DamageMotion: 360
 },
 {
@@ -21580,6 +21951,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1528
 	AttackMotion: 660
+	DamageDelay: 315
 	DamageMotion: 432
 },
 {
@@ -21619,6 +21991,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1540
 	AttackMotion: 840
+	DamageDelay: 405
 	DamageMotion: 504
 },
 {
@@ -21659,6 +22032,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1480
 	AttackMotion: 480
+	DamageDelay: 225
 	DamageMotion: 1056
 },
 {
@@ -21698,6 +22072,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 432
 	AttackMotion: 432
+	DamageDelay: 135
 	DamageMotion: 360
 },
 {
@@ -21737,6 +22112,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1360
 	AttackMotion: 960
+	DamageDelay: 540
 	DamageMotion: 432
 },
 {
@@ -21776,6 +22152,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 2420
 	AttackMotion: 720
+	DamageDelay: 270
 	DamageMotion: 648
 },
 {
@@ -21815,6 +22192,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 2852
 	AttackMotion: 1152
+	DamageDelay: 720
 	DamageMotion: 840
 },
 {
@@ -21854,6 +22232,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 976
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 288
 },
 {
@@ -21893,6 +22272,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1624
 	AttackMotion: 620
+	DamageDelay: 315
 	DamageMotion: 384
 },
 {
@@ -21932,6 +22312,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1420
 	AttackMotion: 1080
+	DamageDelay: 315
 	DamageMotion: 528
 },
 {
@@ -21971,6 +22352,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 824
 	AttackMotion: 780
+	DamageDelay: 360
 	DamageMotion: 420
 },
 {
@@ -22011,6 +22393,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1516
 	AttackMotion: 816
+	DamageDelay: 405
 	DamageMotion: 432
 },
 {
@@ -22050,6 +22433,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 2420
 	AttackMotion: 720
+	DamageDelay: 405
 	DamageMotion: 384
 },
 {
@@ -22089,6 +22473,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1780
 	AttackMotion: 1080
+	DamageDelay: 675
 	DamageMotion: 432
 },
 {
@@ -22128,6 +22513,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 840
 	AttackMotion: 540
+	DamageDelay: 337
 	DamageMotion: 480
 },
 {
@@ -22167,6 +22553,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1720
 	AttackMotion: 500
+	DamageDelay: 1080
 	DamageMotion: 420
 },
 {
@@ -22206,6 +22593,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1960
 	AttackMotion: 620
+	DamageDelay: 810
 	DamageMotion: 480
 },
 {
@@ -22245,6 +22633,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 972
 	AttackMotion: 500
+	DamageDelay: 450
 	DamageMotion: 288
 },
 {
@@ -22284,6 +22673,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1816
 	AttackMotion: 576
+	DamageDelay: 360
 	DamageMotion: 240
 },
 {
@@ -22323,6 +22713,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1020
 	AttackMotion: 500
+	DamageDelay: 506
 	DamageMotion: 768
 },
 {
@@ -22364,6 +22755,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 960
 	AttackMotion: 500
+	DamageDelay: 450
 	DamageMotion: 480
 },
 {
@@ -22403,6 +22795,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 864
 	AttackMotion: 500
+	DamageDelay: 438
 	DamageMotion: 192
 },
 {
@@ -22442,6 +22835,7 @@ mob_db: (
 	MoveSpeed: 350
 	AttackDelay: 1848
 	AttackMotion: 500
+	DamageDelay: 810
 	DamageMotion: 576
 },
 {
@@ -22481,6 +22875,7 @@ mob_db: (
 	MoveSpeed: 350
 	AttackDelay: 1768
 	AttackMotion: 500
+	DamageDelay: 450
 	DamageMotion: 192
 },
 {
@@ -22520,6 +22915,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1500
 	AttackMotion: 500
+	DamageDelay: 1080
 	DamageMotion: 1000
 },
 {
@@ -22560,6 +22956,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 800
 	AttackMotion: 792
+	DamageDelay: 1980
 	DamageMotion: 384
 },
 {
@@ -22600,6 +22997,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1790
 	AttackMotion: 1440
+	DamageDelay: 843
 	DamageMotion: 540
 },
 {
@@ -22639,6 +23037,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 1744
 	AttackMotion: 1344
+	DamageDelay: 900
 	DamageMotion: 600
 },
 {
@@ -22680,6 +23079,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1152
 	AttackMotion: 500
+	DamageDelay: 720
 	DamageMotion: 240
 },
 {
@@ -22722,6 +23122,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 816
 	AttackMotion: 500
+	DamageDelay: 540
 	DamageMotion: 240
 },
 {
@@ -22763,6 +23164,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 768
 	AttackMotion: 500
+	DamageDelay: 450
 	DamageMotion: 384
 },
 {
@@ -22802,6 +23204,7 @@ mob_db: (
 	MoveSpeed: 190
 	AttackDelay: 900
 	AttackMotion: 500
+	DamageDelay: 618
 	DamageMotion: 864
 },
 {
@@ -22841,6 +23244,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 528
 	AttackMotion: 500
+	DamageDelay: 315
 	DamageMotion: 240
 },
 {
@@ -22882,6 +23286,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 672
 	AttackMotion: 500
+	DamageDelay: 630
 	DamageMotion: 192
 },
 {
@@ -22922,6 +23327,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1156
 	AttackMotion: 456
+	DamageDelay: 270
 	DamageMotion: 384
 },
 // Umbala (6.2)
@@ -22967,6 +23373,7 @@ mob_db: (
 	MoveSpeed: 135
 	AttackDelay: 874
 	AttackMotion: 1344
+	DamageDelay: 1260
 	DamageMotion: 576
 	DamageTakenRate: 10
 	MvpExp: 375840
@@ -23023,6 +23430,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 950
 	AttackMotion: 2520
+	DamageDelay: 270
 	DamageMotion: 576
 	Drops: {
 		Tough_Vines: 5335
@@ -23071,6 +23479,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1247
 	AttackMotion: 768
+	DamageDelay: 225
 	DamageMotion: 576
 	Drops: {
 		Solid_Peeling: 6500
@@ -23118,6 +23527,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 2413
 	AttackMotion: 1248
+	DamageDelay: 90
 	DamageMotion: 768
 	Drops: {
 		Solid_Twig: 5000
@@ -23158,6 +23568,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 0
 	AttackMotion: 0
+	DamageDelay: 0
 	DamageMotion: 0
 },
 {
@@ -23197,6 +23608,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1543
 	AttackMotion: 1632
+	DamageDelay: 360
 	DamageMotion: 480
 	Drops: {
 		Heart_Of_Tree: 4000
@@ -23246,6 +23658,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 857
 	AttackMotion: 1056
+	DamageDelay: 393
 	DamageMotion: 576
 	Drops: {
 		Air_Rifle: 4500
@@ -23295,6 +23708,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 912
 	AttackMotion: 1344
+	DamageDelay: 393
 	DamageMotion: 480
 	Drops: {
 		Meat: 4500
@@ -23340,6 +23754,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 864
 	AttackMotion: 864
+	DamageDelay: 270
 	DamageMotion: 672
 	Drops: {
 		Germinating_Sprout: 5500
@@ -23381,6 +23796,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 0
 	AttackMotion: 0
+	DamageDelay: 0
 	DamageMotion: 0
 },
 // Event MVP
@@ -23481,6 +23897,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 917
 	AttackMotion: 1584
+	DamageDelay: 450
 	DamageMotion: 576
 	Drops: {
 		Hanging_Doll: 1800
@@ -23530,6 +23947,7 @@ mob_db: (
 	MoveSpeed: 155
 	AttackDelay: 847
 	AttackMotion: 1152
+	DamageDelay: 360
 	DamageMotion: 480
 	Drops: {
 		Dullahans_Helm: 3200
@@ -23579,6 +23997,7 @@ mob_db: (
 	MoveSpeed: 125
 	AttackDelay: 747
 	AttackMotion: 1632
+	DamageDelay: 1530
 	DamageMotion: 576
 	Drops: {
 		Black_Kitty_Doll: 800
@@ -23629,6 +24048,7 @@ mob_db: (
 	MoveSpeed: 147
 	AttackDelay: 516
 	AttackMotion: 768
+	DamageDelay: 337
 	DamageMotion: 384
 	Drops: {
 		Red_Scarf: 4850
@@ -23678,6 +24098,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 914
 	AttackMotion: 1344
+	DamageDelay: 450
 	DamageMotion: 384
 	Drops: {
 		Old_Manteau: 4171
@@ -23727,6 +24148,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 912
 	AttackMotion: 1248
+	DamageDelay: 393
 	DamageMotion: 576
 	Drops: {
 		Piece_Of_Black_Cloth: 3200
@@ -23775,6 +24197,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 890
 	AttackMotion: 960
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Pumpkin_Bucket: 3200
@@ -23826,6 +24249,7 @@ mob_db: (
 	MoveSpeed: 155
 	AttackDelay: 741
 	AttackMotion: 1536
+	DamageDelay: 506
 	DamageMotion: 480
 	Drops: {
 		Broken_Needle: 4365
@@ -23874,6 +24298,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 854
 	AttackMotion: 2016
+	DamageDelay: 675
 	DamageMotion: 480
 	DamageTakenRate: 10
 	MvpExp: 120060
@@ -23932,6 +24357,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 890
 	AttackMotion: 1320
+	DamageDelay: 1237
 	DamageMotion: 720
 	Drops: {
 		Brigan: 3880
@@ -23981,6 +24407,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1257
 	AttackMotion: 528
+	DamageDelay: 990
 	DamageMotion: 432
 	Drops: {
 		Fan: 4171
@@ -24026,6 +24453,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 600
 	AttackMotion: 840
+	DamageDelay: 450
 	DamageMotion: 504
 	Drops: {
 		Dragon_Fang: 4365
@@ -24074,6 +24502,7 @@ mob_db: (
 	MoveSpeed: 450
 	AttackDelay: 879
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 576
 	Drops: {
 		Milk_Bottle: 1500
@@ -24119,6 +24548,7 @@ mob_db: (
 	MoveSpeed: 445
 	AttackDelay: 106
 	AttackMotion: 1056
+	DamageDelay: 585
 	DamageMotion: 576
 	Drops: {
 		Dried_Sand: 4365
@@ -24167,6 +24597,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1120
 	AttackMotion: 576
+	DamageDelay: 315
 	DamageMotion: 420
 	Drops: {
 		Tiger_Skin_Panties: 4500
@@ -24216,6 +24647,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 576
 	AttackMotion: 960
+	DamageDelay: 900
 	DamageMotion: 480
 	Drops: {
 		Long_Hair: 5500
@@ -24268,6 +24700,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 1728
 	AttackMotion: 816
+	DamageDelay: 225
 	DamageMotion: 1188
 	Drops: {
 		Cyfar: 4850
@@ -24312,6 +24745,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 1152
 	AttackMotion: 672
+	DamageDelay: 405
 	DamageMotion: 672
 	Drops: {
 		Exorcize_Herb: 3000
@@ -24357,6 +24791,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 520
 	AttackMotion: 2304
+	DamageDelay: 2160
 	DamageMotion: 480
 },
 {
@@ -24398,6 +24833,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 1772
 	AttackMotion: 120
+	DamageDelay: 270
 	DamageMotion: 384
 },
 {
@@ -24436,6 +24872,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 1084
 	AttackMotion: 2304
+	DamageDelay: 450
 	DamageMotion: 576
 },
 {
@@ -24475,6 +24912,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 318
 	AttackMotion: 528
+	DamageDelay: 225
 	DamageMotion: 420
 },
 {
@@ -24516,6 +24954,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1504
 	AttackMotion: 840
+	DamageDelay: 270
 	DamageMotion: 900
 },
 {
@@ -24556,6 +24995,7 @@ mob_db: (
 	MoveSpeed: 145
 	AttackDelay: 472
 	AttackMotion: 576
+	DamageDelay: 450
 	DamageMotion: 288
 },
 {
@@ -24593,6 +25033,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1072
 	AttackMotion: 672
+	DamageDelay: 360
 	DamageMotion: 384
 },
 {
@@ -24629,6 +25070,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1092
 	AttackMotion: 792
+	DamageDelay: 405
 	DamageMotion: 480
 },
 {
@@ -24673,6 +25115,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 588
 	AttackMotion: 816
+	DamageDelay: 1530
 	DamageMotion: 420
 },
 {
@@ -24716,6 +25159,7 @@ mob_db: (
 	MoveSpeed: 145
 	AttackDelay: 1290
 	AttackMotion: 1140
+	DamageDelay: 731
 	DamageMotion: 576
 },
 {
@@ -24754,6 +25198,7 @@ mob_db: (
 	MoveSpeed: 190
 	AttackDelay: 480
 	AttackMotion: 840
+	DamageDelay: 585
 	DamageMotion: 432
 },
 {
@@ -24793,6 +25238,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1260
 	AttackMotion: 960
+	DamageDelay: 450
 	DamageMotion: 336
 },
 {
@@ -24833,6 +25279,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1612
 	AttackMotion: 622
+	DamageDelay: 540
 	DamageMotion: 583
 },
 {
@@ -24874,6 +25321,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1120
 	AttackMotion: 620
+	DamageDelay: 360
 	DamageMotion: 240
 },
 {
@@ -24913,6 +25361,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1320
 	AttackMotion: 620
+	DamageDelay: 360
 	DamageMotion: 240
 },
 {
@@ -24952,6 +25401,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1624
 	AttackMotion: 624
+	DamageDelay: 360
 	DamageMotion: 240
 },
 {
@@ -24991,6 +25441,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1624
 	AttackMotion: 624
+	DamageDelay: 360
 	DamageMotion: 240
 },
 {
@@ -25030,6 +25481,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 3074
 	AttackMotion: 1874
+	DamageDelay: 360
 	DamageMotion: 480
 },
 {
@@ -25071,6 +25523,7 @@ mob_db: (
 	MoveSpeed: 120
 	AttackDelay: 1120
 	AttackMotion: 620
+	DamageDelay: 1170
 	DamageMotion: 240
 },
 {
@@ -25107,6 +25560,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1608
 	AttackMotion: 816
+	DamageDelay: 945
 	DamageMotion: 396
 },
 {
@@ -25142,6 +25596,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1152
 	AttackMotion: 1152
+	DamageDelay: 765
 	DamageMotion: 384
 },
 /*{
@@ -25224,6 +25679,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 2012
 	AttackMotion: 1728
+	DamageDelay: 540
 	DamageMotion: 672
 },
 {
@@ -25259,6 +25715,7 @@ mob_db: (
 	MoveSpeed: 155
 	AttackDelay: 1638
 	AttackMotion: 2016
+	DamageDelay: 405
 	DamageMotion: 576
 },
 {
@@ -25298,6 +25755,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1028
 	AttackMotion: 528
+	DamageDelay: 225
 	DamageMotion: 360
 },
 {
@@ -25337,6 +25795,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1528
 	AttackMotion: 528
+	DamageDelay: 225
 	DamageMotion: 360
 },
 {
@@ -25376,6 +25835,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1228
 	AttackMotion: 528
+	DamageDelay: 225
 	DamageMotion: 360
 },
 {
@@ -25417,6 +25877,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1028
 	AttackMotion: 528
+	DamageDelay: 225
 	DamageMotion: 360
 },
 {
@@ -25456,6 +25917,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 2190
 	AttackMotion: 2040
+	DamageDelay: 675
 	DamageMotion: 336
 },
 {
@@ -25494,6 +25956,7 @@ mob_db: (
 	MoveSpeed: 410
 	AttackDelay: 400
 	AttackMotion: 672
+	DamageDelay: 630
 	DamageMotion: 480
 },
 {
@@ -25530,6 +25993,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1956
 	AttackMotion: 756
+	DamageDelay: 438
 	DamageMotion: 528
 },
 {
@@ -25568,6 +26032,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1938
 	AttackMotion: 2112
+	DamageDelay: 1980
 	DamageMotion: 768
 },
 {
@@ -25609,6 +26074,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1576
 	AttackMotion: 576
+	DamageDelay: 315
 	DamageMotion: 384
 },
 {
@@ -25649,6 +26115,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1216
 	AttackMotion: 816
+	DamageDelay: 765
 	DamageMotion: 432
 },
 {
@@ -25684,6 +26151,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 864
 	AttackMotion: 864
+	DamageDelay: 270
 	DamageMotion: 672
 },
 {
@@ -25720,6 +26188,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 1148
 	AttackMotion: 1728
+	DamageDelay: 585
 	DamageMotion: 864
 },
 {
@@ -25757,6 +26226,7 @@ mob_db: (
 	MoveSpeed: 155
 	AttackDelay: 2416
 	AttackMotion: 2016
+	DamageDelay: 945
 	DamageMotion: 432
 },
 {
@@ -25796,6 +26266,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1672
 	AttackMotion: 720
+	DamageDelay: 630
 	DamageMotion: 288
 },
 {
@@ -25835,6 +26306,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1564
 	AttackMotion: 864
+	DamageDelay: 360
 	DamageMotion: 576
 },
 {
@@ -25876,6 +26348,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1003
 	AttackMotion: 1152
+	DamageDelay: 2160
 	DamageMotion: 336
 },
 {
@@ -25912,6 +26385,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1576
 	AttackMotion: 576
+	DamageDelay: 540
 	DamageMotion: 420
 },
 {
@@ -25951,6 +26425,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 2276
 	AttackMotion: 576
+	DamageDelay: 202
 	DamageMotion: 432
 },
 {
@@ -25991,6 +26466,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1439
 	AttackMotion: 1920
+	DamageDelay: 585
 	DamageMotion: 672
 },
 {
@@ -26034,6 +26510,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 637
 	AttackMotion: 1008
+	DamageDelay: 540
 	DamageMotion: 360
 },
 {
@@ -26071,6 +26548,7 @@ mob_db: (
 	MoveSpeed: 140
 	AttackDelay: 512
 	AttackMotion: 756
+	DamageDelay: 506
 	DamageMotion: 360
 },
 {
@@ -26112,6 +26590,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 1816
 	AttackMotion: 576
+	DamageDelay: 765
 	DamageMotion: 240
 },
 {
@@ -26154,6 +26633,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1792
 	AttackMotion: 792
+	DamageDelay: 540
 	DamageMotion: 336
 },
 {
@@ -26197,6 +26677,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1072
 	AttackMotion: 672
+	DamageDelay: 292
 	DamageMotion: 672
 },
 {
@@ -26238,6 +26719,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 828
 	AttackMotion: 528
+	DamageDelay: 270
 	DamageMotion: 192
 },
 {
@@ -26277,6 +26759,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1000
 	AttackMotion: 500
+	DamageDelay: 607
 	DamageMotion: 1000
 },
 {
@@ -26313,6 +26796,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1680
 	AttackMotion: 480
+	DamageDelay: 270
 	DamageMotion: 384
 },
 {
@@ -26349,6 +26833,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1372
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 },
 {
@@ -26388,6 +26873,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1552
 	AttackMotion: 1152
+	DamageDelay: 675
 	DamageMotion: 336
 },
 {
@@ -26427,6 +26913,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1372
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 432
 },
 {
@@ -26462,6 +26949,7 @@ mob_db: (
 	MoveSpeed: 1000
 	AttackDelay: 1432
 	AttackMotion: 432
+	DamageDelay: 168
 	DamageMotion: 576
 },
 {
@@ -26505,6 +26993,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1220
 	AttackMotion: 1080
+	DamageDelay: 315
 	DamageMotion: 648
 },
 {
@@ -26542,6 +27031,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1172
 	AttackMotion: 672
+	DamageDelay: 495
 	DamageMotion: 420
 },
 {
@@ -26581,6 +27071,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1888
 	AttackMotion: 1152
+	DamageDelay: 517
 	DamageMotion: 828
 },
 {
@@ -26616,6 +27107,7 @@ mob_db: (
 	MoveSpeed: 1000
 	AttackDelay: 800
 	AttackMotion: 432
+	DamageDelay: 315
 	DamageMotion: 600
 },
 {
@@ -26658,6 +27150,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 850
 	AttackMotion: 600
+	DamageDelay: 393
 	DamageMotion: 336
 },
 {
@@ -26700,6 +27193,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1080
 	AttackMotion: 648
+	DamageDelay: 607
 	DamageMotion: 480
 },
 {
@@ -26743,6 +27237,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1072
 	AttackMotion: 1056
+	DamageDelay: 990
 	DamageMotion: 384
 	Drops: {
 		Petite_DiablOfs_Wing: 3000
@@ -26796,6 +27291,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1020
 	AttackMotion: 288
+	DamageDelay: 360
 	DamageMotion: 144
 	DamageTakenRate: 10
 	MvpExp: 450000
@@ -26854,6 +27350,7 @@ mob_db: (
 	MoveSpeed: 140
 	AttackDelay: 512
 	AttackMotion: 1152
+	DamageDelay: 360
 	DamageMotion: 672
 	Drops: {
 		Sword_Accessory: 4850
@@ -26944,6 +27441,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 960
 	AttackMotion: 864
+	DamageDelay: 810
 	DamageMotion: 720
 	Drops: {
 		Great_Leaf: 4365
@@ -26993,6 +27491,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1152
 	AttackMotion: 1536
+	DamageDelay: 360
 	DamageMotion: 576
 	Drops: {
 		Zargon: 3500
@@ -27039,6 +27538,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1864
 	AttackMotion: 864
+	DamageDelay: 810
 	DamageMotion: 288
 	Drops: {
 		Iron: 210
@@ -27084,6 +27584,7 @@ mob_db: (
 	MoveSpeed: 1000
 	AttackDelay: 1768
 	AttackMotion: 768
+	DamageDelay: 360
 	DamageMotion: 576
 },
 {
@@ -27119,6 +27620,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 1308
 	AttackMotion: 1008
+	DamageDelay: 450
 	DamageMotion: 480
 },
 {
@@ -27155,6 +27657,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1456
 	AttackMotion: 456
+	DamageDelay: 247
 	DamageMotion: 336
 	Drops: {
 		Orange_Potion: 2000
@@ -27197,6 +27700,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1100
 	AttackMotion: 560
+	DamageDelay: 630
 	DamageMotion: 580
 	Drops: {
 		Stone: 10000
@@ -27242,6 +27746,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 1772
 	AttackMotion: 120
+	DamageDelay: 270
 	DamageMotion: 384
 	Drops: {
 		Orange_Potion: 2000
@@ -27286,6 +27791,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1452
 	AttackMotion: 483
+	DamageDelay: 506
 	DamageMotion: 528
 },
 {
@@ -27322,6 +27828,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 },
 {
@@ -27362,6 +27869,7 @@ mob_db: (
 	MoveSpeed: 140
 	AttackDelay: 512
 	AttackMotion: 1152
+	DamageDelay: 360
 	DamageMotion: 672
 },
 {
@@ -27400,6 +27908,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1020
 	AttackMotion: 720
+	DamageDelay: 562
 	DamageMotion: 384
 },
 {
@@ -27441,6 +27950,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 1732
 	AttackMotion: 1332
+	DamageDelay: 438
 	DamageMotion: 540
 },
 {
@@ -27483,6 +27993,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 2536
 	AttackMotion: 1536
+	DamageDelay: 1440
 	DamageMotion: 672
 },
 {
@@ -27524,6 +28035,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1452
 	AttackMotion: 483
+	DamageDelay: 1215
 	DamageMotion: 528
 },
 {
@@ -27565,6 +28077,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1100
 	AttackMotion: 483
+	DamageDelay: 675
 	DamageMotion: 528
 },
 {
@@ -27606,6 +28119,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1452
 	AttackMotion: 483
+	DamageDelay: 1350
 	DamageMotion: 528
 },
 {
@@ -27642,6 +28156,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1260
 	AttackMotion: 192
+	DamageDelay: 1181
 	DamageMotion: 192
 },
 {
@@ -27684,6 +28199,7 @@ mob_db: (
 	MoveSpeed: 155
 	AttackDelay: 1292
 	AttackMotion: 792
+	DamageDelay: 742
 	DamageMotion: 340
 },
 {
@@ -27727,6 +28243,7 @@ mob_db: (
 	MoveSpeed: 145
 	AttackDelay: 1024
 	AttackMotion: 768
+	DamageDelay: 5130
 	DamageMotion: 480
 },
 {
@@ -27767,6 +28284,7 @@ mob_db: (
 	MoveSpeed: 450
 	AttackDelay: 879
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 576
 },
 {
@@ -27809,6 +28327,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1120
 	AttackMotion: 620
+	DamageDelay: 360
 	DamageMotion: 240
 },
 {
@@ -27850,6 +28369,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 988
 	AttackMotion: 288
+	DamageDelay: 720
 	DamageMotion: 768
 },
 {
@@ -27888,6 +28408,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 600
 	AttackMotion: 840
+	DamageDelay: 450
 	DamageMotion: 504
 	Drops: {
 		Lucky_Candy: 500
@@ -27937,6 +28458,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 2468
 	AttackMotion: 768
+	DamageDelay: 450
 	DamageMotion: 288
 	Drops: {
 		Orange_Potion: 2000
@@ -27983,6 +28505,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1720
 	AttackMotion: 500
+	DamageDelay: 1080
 	DamageMotion: 420
 	Drops: {
 		Orange_Potion: 2000
@@ -28030,6 +28553,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 890
 	AttackMotion: 1320
+	DamageDelay: 1237
 	DamageMotion: 720
 	Drops: {
 		Orange_Potion: 2000
@@ -28072,6 +28596,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 384
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Tube: 4000
@@ -28118,6 +28643,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 648
 	AttackMotion: 480
+	DamageDelay: 281
 	DamageMotion: 360
 	Drops: {
 		Fragment_Of_Crystal: 3000
@@ -28167,6 +28693,7 @@ mob_db: (
 	MoveSpeed: 350
 	AttackDelay: 720
 	AttackMotion: 864
+	DamageDelay: 585
 	DamageMotion: 504
 	Drops: {
 		Dark_Crystal_Fragment: 3000
@@ -28212,6 +28739,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 960
 	AttackMotion: 336
+	DamageDelay: 225
 	DamageMotion: 300
 	Drops: {
 		Old_Pick: 3000
@@ -28262,6 +28790,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1152
 	AttackMotion: 528
+	DamageDelay: 225
 	DamageMotion: 360
 	Drops: {
 		Battered_Kettle: 1000
@@ -28314,6 +28843,7 @@ mob_db: (
 	MoveSpeed: 350
 	AttackDelay: 420
 	AttackMotion: 576
+	DamageDelay: 225
 	DamageMotion: 420
 	Drops: {
 		Long_Limb: 4500
@@ -28361,6 +28891,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 720
 	AttackMotion: 360
+	DamageDelay: 112
 	DamageMotion: 360
 	Drops: {
 		Jubilee: 5000
@@ -28409,6 +28940,7 @@ mob_db: (
 	MoveSpeed: 350
 	AttackDelay: 768
 	AttackMotion: 1440
+	DamageDelay: 495
 	DamageMotion: 672
 	Drops: {
 		Poisonous_Gas: 1000
@@ -28458,6 +28990,7 @@ mob_db: (
 	MoveSpeed: 350
 	AttackDelay: 768
 	AttackMotion: 1440
+	DamageDelay: 495
 	DamageMotion: 672
 	Drops: {
 		Air_Pollutant: 5000
@@ -28508,6 +29041,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 512
 	AttackMotion: 780
+	DamageDelay: 562
 	DamageMotion: 504
 	Drops: {
 		Screw: 3800
@@ -28562,6 +29096,7 @@ mob_db: (
 	MoveSpeed: 220
 	AttackDelay: 128
 	AttackMotion: 1104
+	DamageDelay: 450
 	DamageMotion: 240
 	DamageTakenRate: 10
 	MvpExp: 360000
@@ -28619,6 +29154,7 @@ mob_db: (
 	MoveSpeed: 220
 	AttackDelay: 1152
 	AttackMotion: 528
+	DamageDelay: 225
 	DamageMotion: 360
 },
 {
@@ -28659,6 +29195,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 720
 	AttackMotion: 360
+	DamageDelay: 112
 	DamageMotion: 360
 },
 // Hellion Revenant
@@ -28703,6 +29240,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 432
 	AttackMotion: 384
+	DamageDelay: 360
 	DamageMotion: 192
 	Drops: {
 		Eye_Of_Hellion: 8000
@@ -28752,6 +29290,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 1084
 	AttackMotion: 2304
+	DamageDelay: 360
 	DamageMotion: 576
 	Drops: {
 		Wing_Of_Fly: 1000
@@ -28795,6 +29334,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1400
 	AttackMotion: 960
+	DamageDelay: 225
 	DamageMotion: 504
 	Drops: {
 		Moustache_Of_Mole: 5000
@@ -28841,6 +29381,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 336
 	AttackMotion: 540
+	DamageDelay: 337
 	DamageMotion: 432
 	Drops: {
 		Meat: 1000
@@ -28888,6 +29429,7 @@ mob_db: (
 	MoveSpeed: 130
 	AttackDelay: 576
 	AttackMotion: 960
+	DamageDelay: 900
 	DamageMotion: 480
 	DamageTakenRate: 10
 	MvpExp: 334080
@@ -28945,6 +29487,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1728
 	AttackMotion: 816
+	DamageDelay: 225
 	DamageMotion: 1188
 	Drops: {
 		Cyfar: 4200
@@ -28991,6 +29534,7 @@ mob_db: (
 	MoveSpeed: 140
 	AttackDelay: 432
 	AttackMotion: 540
+	DamageDelay: 225
 	DamageMotion: 432
 	Drops: {
 		Will_Of_Darkness: 3000
@@ -29036,6 +29580,7 @@ mob_db: (
 	MoveSpeed: 190
 	AttackDelay: 336
 	AttackMotion: 840
+	DamageDelay: 281
 	DamageMotion: 360
 	Drops: {
 		Prickly_Fruit: 3000
@@ -29086,6 +29631,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Armlet_Of_Prisoner: 3000
@@ -29137,6 +29683,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Lab_Staff_Record: 2000
@@ -29187,6 +29734,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 225
 	DamageMotion: 288
 	Drops: {
 		Armlet_Of_Prisoner: 3000
@@ -29238,6 +29786,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 1152
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Lab_Staff_Record: 2000
@@ -29288,6 +29837,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Armlet_Of_Prisoner: 3000
@@ -29339,6 +29889,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1152
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Armlet_Of_Prisoner: 3000
@@ -29393,6 +29944,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Carnium: 100
@@ -29440,6 +29992,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Carnium: 100
@@ -29488,6 +30041,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 225
 	DamageMotion: 288
 	Drops: {
 		Carnium: 100
@@ -29536,6 +30090,7 @@ mob_db: (
 	MoveSpeed: 125
 	AttackDelay: 1152
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Carnium: 100
@@ -29584,6 +30139,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Carnium: 100
@@ -29632,6 +30188,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1152
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Carnium: 100
@@ -29680,6 +30237,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	MvpExp: 2321280
 	MvpDrops: {
@@ -29739,6 +30297,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	MvpExp: 2092500
 	MvpDrops: {
@@ -29799,6 +30358,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 225
 	DamageMotion: 288
 	MvpExp: 1777500
 	MvpDrops: {
@@ -29859,6 +30419,7 @@ mob_db: (
 	MoveSpeed: 125
 	AttackDelay: 1152
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	MvpExp: 1732500
 	MvpDrops: {
@@ -29919,6 +30480,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	MvpExp: 2053440
 	MvpDrops: {
@@ -29979,6 +30541,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1152
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	MvpExp: 1620000
 	MvpDrops: {
@@ -30036,6 +30599,7 @@ mob_db: (
 	MoveSpeed: 145
 	AttackDelay: 576
 	AttackMotion: 432
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Lab_Staff_Record: 1000
@@ -30086,6 +30650,7 @@ mob_db: (
 	MoveSpeed: 120
 	AttackDelay: 576
 	AttackMotion: 432
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Armlet_Of_Prisoner: 2000
@@ -30136,6 +30701,7 @@ mob_db: (
 	MoveSpeed: 120
 	AttackDelay: 576
 	AttackMotion: 432
+	DamageDelay: 225
 	DamageMotion: 288
 	Drops: {
 		Armlet_Of_Prisoner: 1000
@@ -30186,6 +30752,7 @@ mob_db: (
 	MoveSpeed: 130
 	AttackDelay: 576
 	AttackMotion: 432
+	DamageDelay: 315
 	DamageMotion: 288
 	Drops: {
 		Armlet_Of_Prisoner: 500
@@ -30236,6 +30803,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 576
 	AttackMotion: 432
+	DamageDelay: 315
 	DamageMotion: 288
 	Drops: {
 		Lab_Staff_Record: 2000
@@ -30286,6 +30854,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 576
 	AttackMotion: 432
+	DamageDelay: 315
 	DamageMotion: 288
 	Drops: {
 		Mementos: 1000
@@ -30341,6 +30910,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1008
 	AttackMotion: 864
+	DamageDelay: 270
 	DamageMotion: 288
 	MvpExp: 527200
 	MvpDrops: {
@@ -30397,6 +30967,7 @@ mob_db: (
 	MoveSpeed: 120
 	AttackDelay: 1008
 	AttackMotion: 864
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Gift_Box: 10
@@ -30440,6 +31011,7 @@ mob_db: (
 	MoveSpeed: 120
 	AttackDelay: 1008
 	AttackMotion: 864
+	DamageDelay: 225
 	DamageMotion: 288
 	Drops: {
 		Gift_Box: 10
@@ -30483,6 +31055,7 @@ mob_db: (
 	MoveSpeed: 130
 	AttackDelay: 1008
 	AttackMotion: 864
+	DamageDelay: 315
 	DamageMotion: 288
 	Drops: {
 		Gift_Box: 10
@@ -30526,6 +31099,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1008
 	AttackMotion: 864
+	DamageDelay: 315
 	DamageMotion: 288
 	Drops: {
 		Gift_Box: 10
@@ -30569,6 +31143,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1008
 	AttackMotion: 864
+	DamageDelay: 315
 	DamageMotion: 288
 	Drops: {
 		Gift_Box: 10
@@ -30608,6 +31183,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1536
 	AttackMotion: 960
+	DamageDelay: 450
 	DamageMotion: 480
 	Drops: {
 		Large_Jellopy: 5000
@@ -30648,6 +31224,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1536
 	AttackMotion: 960
+	DamageDelay: 450
 	DamageMotion: 480
 	Drops: {
 		Large_Jellopy: 5000
@@ -30689,6 +31266,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1536
 	AttackMotion: 960
+	DamageDelay: 450
 	DamageMotion: 480
 	Drops: {
 		Large_Jellopy: 5000
@@ -30729,6 +31307,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1536
 	AttackMotion: 960
+	DamageDelay: 450
 	DamageMotion: 480
 	Drops: {
 		Large_Jellopy: 5000
@@ -30775,6 +31354,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 580
 	AttackMotion: 288
+	DamageDelay: 180
 	DamageMotion: 360
 	Drops: {
 		Screw: 5000
@@ -30823,6 +31403,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 576
 	AttackMotion: 720
+	DamageDelay: 315
 	DamageMotion: 432
 	Drops: {
 		Dimik_Card: 1
@@ -30865,6 +31446,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 576
 	AttackMotion: 720
+	DamageDelay: 315
 	DamageMotion: 432
 	Drops: {
 		Old_Steel_Plate: 2000
@@ -30914,6 +31496,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 576
 	AttackMotion: 720
+	DamageDelay: 315
 	DamageMotion: 432
 	Drops: {
 		Old_Steel_Plate: 2000
@@ -30963,6 +31546,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 576
 	AttackMotion: 720
+	DamageDelay: 315
 	DamageMotion: 432
 	Drops: {
 		Old_Steel_Plate: 2000
@@ -31012,6 +31596,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 576
 	AttackMotion: 720
+	DamageDelay: 315
 	DamageMotion: 432
 	Drops: {
 		Old_Steel_Plate: 2000
@@ -31059,6 +31644,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1368
 	AttackMotion: 1344
+	DamageDelay: 450
 	DamageMotion: 432
 	Drops: {
 		Stone: 2000
@@ -31102,6 +31688,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 504
 	AttackMotion: 1020
+	DamageDelay: 562
 	DamageMotion: 360
 	Drops: {
 		Venatu_Card: 1
@@ -31144,6 +31731,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 504
 	AttackMotion: 1020
+	DamageDelay: 562
 	DamageMotion: 360
 	Drops: {
 		Screw: 2000
@@ -31193,6 +31781,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 504
 	AttackMotion: 1020
+	DamageDelay: 562
 	DamageMotion: 360
 	Drops: {
 		Screw: 2000
@@ -31242,6 +31831,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 504
 	AttackMotion: 1020
+	DamageDelay: 562
 	DamageMotion: 360
 	Drops: {
 		Screw: 2000
@@ -31291,6 +31881,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 504
 	AttackMotion: 1020
+	DamageDelay: 562
 	DamageMotion: 360
 	Drops: {
 		Screw: 2000
@@ -31340,6 +31931,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 504
 	AttackMotion: 480
+	DamageDelay: 270
 	DamageMotion: 360
 	Drops: {
 		Harpys_Feather: 4000
@@ -31388,6 +31980,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1872
 	AttackMotion: 360
+	DamageDelay: 225
 	DamageMotion: 864
 	Drops: {
 		Skull: 3000
@@ -31438,6 +32031,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1536
 	AttackMotion: 1056
+	DamageDelay: 315
 	DamageMotion: 1152
 	Drops: {
 		Empty_Bottle: 5000
@@ -31487,6 +32081,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1536
 	AttackMotion: 960
+	DamageDelay: 450
 	DamageMotion: 480
 },
 {
@@ -31526,6 +32121,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 1080
 	AttackMotion: 288
+	DamageDelay: 180
 	DamageMotion: 360
 },
 {
@@ -31569,6 +32165,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 504
 	AttackMotion: 912
+	DamageDelay: 495
 	DamageMotion: 432
 	MvpExp: 100000
 	MvpDrops: {
@@ -31624,6 +32221,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 672
 	AttackMotion: 864
+	DamageDelay: 472
 	DamageMotion: 288
 	Drops: {
 		Large_Jellopy: 1000
@@ -31670,6 +32268,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1152
 	AttackMotion: 1152
+	DamageDelay: 315
 	DamageMotion: 480
 	Drops: {
 		Leaflet_Of_Aloe: 1500
@@ -31717,6 +32316,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 576
 	AttackMotion: 432
+	DamageDelay: 360
 	DamageMotion: 360
 	DamageTakenRate: 10
 	MvpExp: 167040
@@ -31778,6 +32378,7 @@ mob_db: (
 	MoveSpeed: 130
 	AttackDelay: 576
 	AttackMotion: 960
+	DamageDelay: 900
 	DamageMotion: 480
 },
 {
@@ -31816,6 +32417,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 1120
 	AttackMotion: 552
+	DamageDelay: 2340
 	DamageMotion: 0
 	Drops: {
 		New_Year_Rice_Cake: 5000
@@ -31858,6 +32460,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1152
 	AttackMotion: 1536
+	DamageDelay: 360
 	DamageMotion: 576
 	Drops: {
 		Leaflet_Of_Aloe: 1
@@ -31907,6 +32510,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 140
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 504
 	Drops: {
 		Raccoon_Leaf: 500
@@ -31956,6 +32560,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1056
 	AttackMotion: 1056
+	DamageDelay: 1215
 	DamageMotion: 336
 	Drops: {
 		Scell: 100
@@ -32004,6 +32609,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 912
 	AttackMotion: 1248
+	DamageDelay: 1215
 	DamageMotion: 576
 	Drops: {
 		Scell: 100
@@ -32051,6 +32657,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1000
 	AttackMotion: 500
+	DamageDelay: 1215
 	DamageMotion: 1000
 	Drops: {
 		Scell: 100
@@ -32098,6 +32705,7 @@ mob_db: (
 	MoveSpeed: 350
 	AttackDelay: 768
 	AttackMotion: 1440
+	DamageDelay: 1215
 	DamageMotion: 672
 	Drops: {
 		Scell: 100
@@ -32145,6 +32753,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 720
 	AttackMotion: 360
+	DamageDelay: 1215
 	DamageMotion: 360
 	Drops: {
 		Scell: 100
@@ -32195,6 +32804,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 176
 	AttackMotion: 912
+	DamageDelay: 495
 	DamageMotion: 300
 	Drops: {
 		Worn_Out_Page: 4000
@@ -32244,6 +32854,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 168
 	AttackMotion: 480
+	DamageDelay: 225
 	DamageMotion: 360
 	Drops: {
 		Old_Blue_Box: 30
@@ -32297,6 +32908,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 432
 	AttackMotion: 480
+	DamageDelay: 281
 	DamageMotion: 360
 	Drops: {
 		Blue_Feather: 500
@@ -32350,6 +32962,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 432
 	AttackMotion: 420
+	DamageDelay: 225
 	DamageMotion: 360
 	Drops: {
 		Red_Feather: 200
@@ -32402,6 +33015,7 @@ mob_db: (
 	MoveSpeed: 120
 	AttackDelay: 360
 	AttackMotion: 480
+	DamageDelay: 225
 	DamageMotion: 360
 	Drops: {
 		Red_Feather: 400
@@ -32455,6 +33069,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 576
 	AttackMotion: 420
+	DamageDelay: 360
 	DamageMotion: 360
 	Drops: {
 		Blue_Feather: 200
@@ -32509,6 +33124,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 432
 	AttackMotion: 288
+	DamageDelay: 180
 	DamageMotion: 420
 	Drops: {
 		Brigan: 1000
@@ -32562,6 +33178,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 160
 	AttackMotion: 528
+	DamageDelay: 360
 	DamageMotion: 360
 	Drops: {
 		Brigan: 1000
@@ -32615,6 +33232,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 160
 	AttackMotion: 480
+	DamageDelay: 281
 	DamageMotion: 360
 	Drops: {
 		Brigan: 1000
@@ -32668,6 +33286,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 160
 	AttackMotion: 672
+	DamageDelay: 450
 	DamageMotion: 480
 	Drops: {
 		Brigan: 1000
@@ -32721,6 +33340,7 @@ mob_db: (
 	MoveSpeed: 120
 	AttackDelay: 115
 	AttackMotion: 816
+	DamageDelay: 630
 	DamageMotion: 504
 	DamageTakenRate: 10
 	MvpExp: 649700
@@ -32781,6 +33401,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 115
 	AttackMotion: 288
+	DamageDelay: 180
 	DamageMotion: 420
 	Drops: {
 		Brigan: 1000
@@ -32829,6 +33450,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 160
 	AttackMotion: 528
+	DamageDelay: 360
 	DamageMotion: 360
 	Drops: {
 		Brigan: 1000
@@ -32877,6 +33499,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 160
 	AttackMotion: 480
+	DamageDelay: 281
 	DamageMotion: 360
 	Drops: {
 		Brigan: 1000
@@ -32925,6 +33548,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 160
 	AttackMotion: 672
+	DamageDelay: 450
 	DamageMotion: 480
 	Drops: {
 		Brigan: 1000
@@ -32970,6 +33594,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 168
 	AttackMotion: 1008
+	DamageDelay: 495
 	DamageMotion: 300
 	Drops: {
 		Light_Granule: 500
@@ -33019,6 +33644,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 108
 	AttackMotion: 576
+	DamageDelay: 360
 	DamageMotion: 432
 	Drops: {
 		Black_wing_Brooch: 10
@@ -33068,6 +33694,7 @@ mob_db: (
 	MoveSpeed: 110
 	AttackDelay: 151
 	AttackMotion: 288
+	DamageDelay: 225
 	DamageMotion: 360
 	Drops: {
 		Green_Herb: 3000
@@ -33113,6 +33740,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 168
 	AttackMotion: 768
+	DamageDelay: 495
 	DamageMotion: 360
 	Drops: {
 		Blue_Potion: 150
@@ -33162,6 +33790,7 @@ mob_db: (
 	MoveSpeed: 120
 	AttackDelay: 108
 	AttackMotion: 576
+	DamageDelay: 360
 	DamageMotion: 432
 	Drops: {
 		Delicious_Fish: 5100
@@ -33211,6 +33840,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 252
 	AttackMotion: 816
+	DamageDelay: 495
 	DamageMotion: 480
 	Drops: {
 		Yellow_Herb: 2000
@@ -33261,6 +33891,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 432
 	AttackMotion: 936
+	DamageDelay: 225
 	DamageMotion: 360
 	DamageTakenRate: 10
 	MvpExp: 2160000
@@ -33322,6 +33953,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 140
 	AttackMotion: 672
+	DamageDelay: 360
 	DamageMotion: 432
 	Drops: {
 		Dragons_Skin: 4000
@@ -33363,6 +33995,7 @@ mob_db: (
 	MoveSpeed: 1000
 	AttackDelay: 24
 	AttackMotion: 0
+	DamageDelay: 22
 	DamageMotion: 0
 	Drops: {
 		Elunium: 5
@@ -33409,6 +34042,7 @@ mob_db: (
 	MoveSpeed: 240
 	AttackDelay: 1180
 	AttackMotion: 480
+	DamageDelay: 180
 	DamageMotion: 648
 	Drops: {
 		Pumpkin_Bucket: 1000
@@ -33457,6 +34091,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 1008
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 },
 {
@@ -33492,6 +34127,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1536
 	AttackMotion: 960
+	DamageDelay: 450
 	DamageMotion: 480
 },
 {
@@ -33528,6 +34164,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Stone: 10000
@@ -33567,6 +34204,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1456
 	AttackMotion: 456
+	DamageDelay: 247
 	DamageMotion: 336
 },
 {
@@ -33603,6 +34241,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1624
 	AttackMotion: 624
+	DamageDelay: 292
 	DamageMotion: 576
 },
 {
@@ -33640,6 +34279,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1600
 	AttackMotion: 900
+	DamageDelay: 236
 	DamageMotion: 240
 },
 {
@@ -33677,6 +34317,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 868
 	AttackMotion: 480
+	DamageDelay: 540
 	DamageMotion: 120
 },
 {
@@ -33714,6 +34355,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 980
 	AttackMotion: 600
+	DamageDelay: 270
 	DamageMotion: 384
 },
 {
@@ -33758,6 +34400,7 @@ mob_db: (
 	MoveSpeed: 190
 	AttackDelay: 480
 	AttackMotion: 480
+	DamageDelay: 180
 	DamageMotion: 288
 	Drops: {
 		Warrior_Symbol: 10000
@@ -33844,6 +34487,7 @@ mob_db: (
 	MoveSpeed: 140
 	AttackDelay: 1152
 	AttackMotion: 576
+	DamageDelay: 360
 	DamageMotion: 432
 	Drops: {
 	}
@@ -33889,6 +34533,7 @@ mob_db: (
 	MoveSpeed: 130
 	AttackDelay: 1152
 	AttackMotion: 576
+	DamageDelay: 360
 	DamageMotion: 432
 	DamageTakenRate: 10
 	MvpExp: 900000
@@ -33946,6 +34591,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1080
 	AttackMotion: 480
+	DamageDelay: 225
 	DamageMotion: 504
 	Drops: {
 		Burnt_Parts: 2000
@@ -33996,6 +34642,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1296
 	AttackMotion: 432
+	DamageDelay: 270
 	DamageMotion: 360
 	Drops: {
 		Burnt_Parts: 2000
@@ -34042,6 +34689,7 @@ mob_db: (
 	MoveSpeed: 220
 	AttackDelay: 1440
 	AttackMotion: 576
+	DamageDelay: 315
 	DamageMotion: 600
 	Drops: {
 		Brigan: 4000
@@ -34091,6 +34739,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 720
 	AttackMotion: 360
+	DamageDelay: 337
 	DamageMotion: 360
 	Drops: {
 		Burnt_Parts: 100
@@ -34138,6 +34787,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1080
 	AttackMotion: 480
+	DamageDelay: 225
 	DamageMotion: 504
 	Drops: {
 		Sturdy_Iron_Piece: 500
@@ -34181,6 +34831,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1296
 	AttackMotion: 432
+	DamageDelay: 270
 	DamageMotion: 360
 	Drops: {
 		Sturdy_Iron_Piece: 500
@@ -34223,6 +34874,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1248
 	AttackMotion: 1248
+	DamageDelay: 315
 	DamageMotion: 240
 	Drops: {
 		Undelivered_Gift: 10000
@@ -34266,6 +34918,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1078
 	AttackMotion: 768
+	DamageDelay: 540
 	DamageMotion: 384
 },
 {
@@ -34305,6 +34958,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1248
 	AttackMotion: 1248
+	DamageDelay: 405
 	DamageMotion: 432
 	Drops: {
 		Undelivered_Gift: 10000
@@ -34347,6 +35001,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 964
 	AttackMotion: 864
+	DamageDelay: 787
 	DamageMotion: 288
 },
 {
@@ -34385,6 +35040,7 @@ mob_db: (
 	MoveSpeed: 110
 	AttackDelay: 720
 	AttackMotion: 360
+	DamageDelay: 337
 	DamageMotion: 360
 	Drops: {
 		Sturdy_Iron_Piece: 500
@@ -34427,6 +35083,7 @@ mob_db: (
 	MoveSpeed: 220
 	AttackDelay: 1440
 	AttackMotion: 576
+	DamageDelay: 315
 	DamageMotion: 600
 	Drops: {
 		Sturdy_Iron_Piece: 500
@@ -34470,6 +35127,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1576
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 576
 },
 {
@@ -34509,6 +35167,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1576
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 576
 },
 {
@@ -34549,6 +35208,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 1720
 	AttackMotion: 1320
+	DamageDelay: 1012
 	DamageMotion: 360
 },
 {
@@ -34583,6 +35243,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 1
 	AttackMotion: 1
+	DamageDelay: 1080
 	DamageMotion: 1
 },
 // Odin's Temple
@@ -34627,6 +35288,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 576
 	AttackMotion: 576
+	DamageDelay: 472
 	DamageMotion: 480
 	DamageTakenRate: 10
 	MvpExp: 1000000
@@ -34684,6 +35346,7 @@ mob_db: (
 	MoveSpeed: 190
 	AttackDelay: 720
 	AttackMotion: 384
+	DamageDelay: 337
 	DamageMotion: 480
 	Drops: {
 		Rune_Of_Darkness: 3500
@@ -34735,6 +35398,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 480
 	AttackMotion: 576
+	DamageDelay: 180
 	DamageMotion: 432
 	Drops: {
 		Rune_Of_Darkness: 3500
@@ -34787,6 +35451,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 672
 	AttackMotion: 780
+	DamageDelay: 337
 	DamageMotion: 480
 	Drops: {
 		Rune_Of_Darkness: 6000
@@ -34840,6 +35505,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 672
 	AttackMotion: 780
+	DamageDelay: 337
 	DamageMotion: 480
 	Drops: {
 		Rune_Of_Darkness: 6000
@@ -34892,6 +35558,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 140
 	AttackMotion: 672
+	DamageDelay: 360
 	DamageMotion: 432
 },
 {
@@ -34931,6 +35598,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 168
 	AttackMotion: 1008
+	DamageDelay: 495
 	DamageMotion: 300
 },
 {
@@ -34970,6 +35638,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 108
 	AttackMotion: 576
+	DamageDelay: 360
 	DamageMotion: 432
 },
 {
@@ -35009,6 +35678,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 168
 	AttackMotion: 768
+	DamageDelay: 495
 	DamageMotion: 360
 },
 {
@@ -35048,6 +35718,7 @@ mob_db: (
 	MoveSpeed: 120
 	AttackDelay: 108
 	AttackMotion: 576
+	DamageDelay: 360
 	DamageMotion: 432
 },
 {
@@ -35088,6 +35759,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 720
 	AttackMotion: 384
+	DamageDelay: 337
 	DamageMotion: 480
 	Drops: {
 		Rune_Of_Darkness: 500
@@ -35131,6 +35803,7 @@ mob_db: (
 	MoveSpeed: 130
 	AttackDelay: 480
 	AttackMotion: 576
+	DamageDelay: 180
 	DamageMotion: 432
 	Drops: {
 		Rune_Of_Darkness: 500
@@ -35175,6 +35848,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 672
 	AttackMotion: 780
+	DamageDelay: 337
 	DamageMotion: 480
 	Drops: {
 		Rune_Of_Darkness: 500
@@ -35219,6 +35893,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 672
 	AttackMotion: 780
+	DamageDelay: 337
 	DamageMotion: 480
 	Drops: {
 		Rune_Of_Darkness: 500
@@ -35265,6 +35940,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 576
 	AttackMotion: 576
+	DamageDelay: 472
 	DamageMotion: 480
 	Drops: {
 		Valhalla_Flower: 160
@@ -35309,6 +35985,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 292
 	DamageMotion: 384
 	MvpDrops: {
 		Jellopy: 5000
@@ -35353,6 +36030,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 990
 	DamageMotion: 384
 	MvpDrops: {
 		Jellopy: 5000
@@ -35402,6 +36080,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1344
 	AttackMotion: 2880
+	DamageDelay: 270
 	DamageMotion: 576
 	DamageTakenRate: 10
 	MvpExp: 1080000
@@ -35458,6 +36137,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 768
 	AttackMotion: 360
+	DamageDelay: 281
 	DamageMotion: 360
 	Drops: {
 		Suspicious_Hat: 2500
@@ -35508,6 +36188,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 768
 	AttackMotion: 360
+	DamageDelay: 281
 	DamageMotion: 360
 	Drops: {
 		Suspicious_Hat: 2500
@@ -35557,6 +36238,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 768
 	AttackMotion: 360
+	DamageDelay: 281
 	DamageMotion: 360
 	Drops: {
 		White_Mask: 2500
@@ -35606,6 +36288,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 768
 	AttackMotion: 360
+	DamageDelay: 337
 	DamageMotion: 432
 	Drops: {
 		White_Mask: 2500
@@ -35656,6 +36339,7 @@ mob_db: (
 	MoveSpeed: 140
 	AttackDelay: 960
 	AttackMotion: 528
+	DamageDelay: 360
 	DamageMotion: 432
 	Drops: {
 		Prickly_Fruit_: 1000
@@ -35706,6 +36390,7 @@ mob_db: (
 	MoveSpeed: 190
 	AttackDelay: 576
 	AttackMotion: 432
+	DamageDelay: 315
 	DamageMotion: 300
 	Drops: {
 		Prickly_Fruit_: 1000
@@ -35754,6 +36439,7 @@ mob_db: (
 	MoveSpeed: 220
 	AttackDelay: 936
 	AttackMotion: 1020
+	DamageDelay: 618
 	DamageMotion: 420
 	Drops: {
 		Ice_Heart: 3000
@@ -35800,6 +36486,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 432
 	AttackMotion: 648
+	DamageDelay: 405
 	DamageMotion: 240
 	Drops: {
 		Ice_Heart: 500
@@ -35846,6 +36533,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 861
 	AttackMotion: 660
+	DamageDelay: 562
 	DamageMotion: 144
 	Drops: {
 		Ice_Heart: 5000
@@ -35897,6 +36585,7 @@ mob_db: (
 	MoveSpeed: 190
 	AttackDelay: 576
 	AttackMotion: 370
+	DamageDelay: 281
 	DamageMotion: 270
 	Drops: {
 		Ice_Heart: 3000
@@ -35949,6 +36638,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 432
 	AttackMotion: 840
+	DamageDelay: 618
 	DamageMotion: 216
 	DamageTakenRate: 10
 	MvpExp: 517788
@@ -36000,6 +36690,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 672
 	AttackMotion: 648
+	DamageDelay: 472
 	DamageMotion: 360
 	Drops: {
 		Sticky_Poison: 3000
@@ -36045,6 +36736,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 864
 	AttackMotion: 576
+	DamageDelay: 472
 	DamageMotion: 336
 	Drops: {
 		Sticky_Poison: 3000
@@ -36093,6 +36785,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1500
 	AttackMotion: 500
+	DamageDelay: 562
 	DamageMotion: 1000
 	Drops: {
 		Rotten_Meat: 3000
@@ -36140,6 +36833,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 864
 	AttackMotion: 624
+	DamageDelay: 450
 	DamageMotion: 360
 	Drops: {
 		Rotten_Meat: 3000
@@ -36183,6 +36877,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 936
 	AttackMotion: 792
+	DamageDelay: 742
 	DamageMotion: 432
 	Drops: {
 		Jellopy: 1000
@@ -36235,6 +36930,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 576
 	AttackMotion: 600
+	DamageDelay: 450
 	DamageMotion: 240
 	DamageTakenRate: 10
 	MvpExp: 540000
@@ -36292,6 +36988,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 768
 	AttackMotion: 360
+	DamageDelay: 281
 	DamageMotion: 360
 	Drops: {
 		Suspicious_Hat: 1
@@ -36335,6 +37032,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 768
 	AttackMotion: 360
+	DamageDelay: 281
 	DamageMotion: 360
 	Drops: {
 		Suspicious_Hat: 1
@@ -36378,6 +37076,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 861
 	AttackMotion: 660
+	DamageDelay: 562
 	DamageMotion: 144
 	Drops: {
 		Ice_Heart: 1
@@ -36416,6 +37115,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 1344
 	AttackMotion: 0
+	DamageDelay: 1260
 	DamageMotion: 0
 	Drops: {
 		Ice_Piece: 1000
@@ -36465,6 +37165,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 512
 	AttackMotion: 528
+	DamageDelay: 405
 	DamageMotion: 240
 	Drops: {
 		Golden_Jewel_: 3000
@@ -36510,6 +37211,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 864
 	AttackMotion: 624
+	DamageDelay: 450
 	DamageMotion: 360
 },
 {
@@ -36544,6 +37246,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 96
 	AttackMotion: 96
+	DamageDelay: 0
 	DamageMotion: 96
 	Drops: {
 		Small_Horn_Of_Devil: 5000
@@ -36592,6 +37295,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1332
 	AttackMotion: 1332
+	DamageDelay: 877
 	DamageMotion: 672
 	Drops: {
 	}
@@ -36634,6 +37338,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 412
 	AttackMotion: 840
+	DamageDelay: 562
 	DamageMotion: 300
 },
 {
@@ -36677,6 +37382,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 828
 	AttackMotion: 528
+	DamageDelay: 270
 	DamageMotion: 192
 	Drops: {
 		Pole_Axe: 100
@@ -36728,6 +37434,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 768
 	AttackMotion: 432
+	DamageDelay: 337
 	DamageMotion: 360
 	Drops: {
 		White_Mask: 2500
@@ -36777,6 +37484,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 768
 	AttackMotion: 432
+	DamageDelay: 810
 	DamageMotion: 360
 	Drops: {
 		Kandura: 10
@@ -36867,6 +37575,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Evil_Mind: 10000
@@ -36913,6 +37622,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Evil_Mind: 10000
@@ -36960,6 +37670,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 225
 	DamageMotion: 288
 	Drops: {
 		Evil_Mind: 10000
@@ -37007,6 +37718,7 @@ mob_db: (
 	MoveSpeed: 125
 	AttackDelay: 1152
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	MvpExp: 9000
 	Drops: {
@@ -37054,6 +37766,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Evil_Mind: 10000
@@ -37101,6 +37814,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1152
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Evil_Mind: 10000
@@ -37147,6 +37861,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		3D_Glasses_Box: 5000
@@ -37193,6 +37908,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		3D_Glasses_Box: 5000
@@ -37240,6 +37956,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 225
 	DamageMotion: 288
 	Drops: {
 		3D_Glasses_Box: 5000
@@ -37287,6 +38004,7 @@ mob_db: (
 	MoveSpeed: 125
 	AttackDelay: 1152
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		3D_Glasses_Box: 5000
@@ -37334,6 +38052,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		3D_Glasses_Box: 5000
@@ -37381,6 +38100,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1152
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		3D_Glasses_Box: 5000
@@ -37421,6 +38141,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1576
 	AttackMotion: 576
+	DamageDelay: 540
 	DamageMotion: 420
 	Drops: {
 		Sunglasses: 100
@@ -37463,6 +38184,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 890
 	AttackMotion: 960
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Chocolate: 10000
@@ -37513,6 +38235,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 972
 	AttackMotion: 672
+	DamageDelay: 360
 	DamageMotion: 432
 	MvpDrops: {
 		Old_Violet_Box: 5500
@@ -37605,6 +38328,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1320
 	AttackMotion: 0
+	DamageDelay: 607
 	DamageMotion: 300
 },
 {
@@ -37639,6 +38363,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 96
 	AttackMotion: 96
+	DamageDelay: 0
 	DamageMotion: 96
 	MvpDrops: {
 		Fatty_Chubby_Earthworm: 5000
@@ -37691,6 +38416,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 972
 	AttackMotion: 936
+	DamageDelay: 225
 	DamageMotion: 360
 	MvpDrops: {
 		Bloody_Dead_Branch: 5500
@@ -37746,6 +38472,7 @@ mob_db: (
 	MoveSpeed: 1000
 	AttackDelay: 1020
 	AttackMotion: 500
+	DamageDelay: 506
 	DamageMotion: 768
 	Drops: {
 		Piece_Of_Cogwheel: 7000
@@ -37790,6 +38517,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1504
 	AttackMotion: 840
+	DamageDelay: 270
 	DamageMotion: 900
 	Drops: {
 		Wooden_Block_: 2000
@@ -37829,6 +38557,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1260
 	AttackMotion: 192
+	DamageDelay: 1181
 	DamageMotion: 192
 	Drops: {
 		Wooden_Block_: 2000
@@ -37871,6 +38600,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1120
 	AttackMotion: 420
+	DamageDelay: 168
 	DamageMotion: 288
 	Drops: {
 		Wooden_Block_: 2000
@@ -37916,6 +38646,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 980
 	AttackMotion: 600
+	DamageDelay: 270
 	DamageMotion: 384
 	Drops: {
 		Wooden_Block_: 3000
@@ -37960,6 +38691,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1452
 	AttackMotion: 483
+	DamageDelay: 506
 	DamageMotion: 528
 	Drops: {
 		Wooden_Block_: 3000
@@ -38003,6 +38735,7 @@ mob_db: (
 	MoveSpeed: 450
 	AttackDelay: 879
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 576
 	Drops: {
 		Wooden_Block_: 5000
@@ -38048,6 +38781,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1120
 	AttackMotion: 620
+	DamageDelay: 360
 	DamageMotion: 240
 	Drops: {
 		Wooden_Block_: 5000
@@ -38092,6 +38826,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1576
 	AttackMotion: 576
+	DamageDelay: 315
 	DamageMotion: 384
 	Drops: {
 		Wooden_Block_: 3000
@@ -38136,6 +38871,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1260
 	AttackMotion: 192
+	DamageDelay: 1181
 	DamageMotion: 192
 	Drops: {
 		Wooden_Block_: 3000
@@ -38181,6 +38917,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1960
 	AttackMotion: 960
+	DamageDelay: 180
 	DamageMotion: 384
 	Drops: {
 		Bag_Of_Rice: 6000
@@ -38337,6 +39074,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 140
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Burning_Heart: 3000
@@ -38390,6 +39128,7 @@ mob_db: (
 	MoveSpeed: 130
 	AttackDelay: 212
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 360
 	DamageTakenRate: 10
 	MvpExp: 3348000
@@ -38450,6 +39189,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 800
 	AttackMotion: 600
+	DamageDelay: 506
 	DamageMotion: 288
 	Drops: {
 		Burning_Heart: 3000
@@ -38503,6 +39243,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 140
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 },
 {
@@ -38546,6 +39287,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 800
 	AttackMotion: 600
+	DamageDelay: 506
 	DamageMotion: 288
 },
 {
@@ -38582,6 +39324,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1472
 	AttackMotion: 384
+	DamageDelay: 315
 	DamageMotion: 288
 	Drops: {
 		Burning_Heart: 3000
@@ -38628,6 +39371,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 824
 	AttackMotion: 432
+	DamageDelay: 337
 	DamageMotion: 360
 	Drops: {
 		Hot_Hair: 3000
@@ -38675,6 +39419,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1548
 	AttackMotion: 384
+	DamageDelay: 225
 	DamageMotion: 288
 	Drops: {
 		Great_Nature: 30
@@ -38729,6 +39474,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 800
 	AttackMotion: 600
+	DamageDelay: 337
 	DamageMotion: 360
 	Drops: {
 		Drill_Katar: 50
@@ -38778,6 +39524,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1960
 	AttackMotion: 480
+	DamageDelay: 180
 	DamageMotion: 384
 	Drops: {
 		Leaf_Of_Yggdrasil: 3000
@@ -38823,6 +39570,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1576
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 576
 	Drops: {
 		Copper_Coin_: 1000
@@ -38863,6 +39611,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1576
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 576
 	Drops: {
 		Copper_Coin_: 1000
@@ -38907,6 +39656,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1576
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 576
 	Drops: {
 		Copper_Coin_: 1000
@@ -38952,6 +39702,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1384
 	AttackMotion: 768
+	DamageDelay: 450
 	DamageMotion: 336
 	Drops: {
 		Copper_Coin_: 1000
@@ -39086,6 +39837,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 768
 	AttackMotion: 768
+	DamageDelay: 540
 	DamageMotion: 576
 },
 {
@@ -39129,6 +39881,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1072
 	AttackMotion: 672
+	DamageDelay: 180
 	DamageMotion: 384
 },
 {
@@ -39213,6 +39966,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1100
 	AttackMotion: 560
+	DamageDelay: 630
 	DamageMotion: 580
 },
 {
@@ -39256,6 +40010,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 292
 	DamageMotion: 384
 },
 {
@@ -39299,6 +40054,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 990
 	DamageMotion: 384
 },
 {
@@ -39335,6 +40091,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1960
 	AttackMotion: 960
+	DamageDelay: 450
 	DamageMotion: 384
 	Drops: {
 		Yellow_Live: 70
@@ -39431,6 +40188,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1560
 	AttackMotion: 360
+	DamageDelay: 180
 	DamageMotion: 360
 	Drops: {
 		Old_Frying_Pan: 9000
@@ -39477,6 +40235,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Garlet: 3200
@@ -39522,6 +40281,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 2208
 	AttackMotion: 1008
+	DamageDelay: 540
 	DamageMotion: 324
 	Drops: {
 		Single_Cell: 9000
@@ -39567,6 +40327,7 @@ mob_db: (
 	MoveSpeed: 1000
 	AttackDelay: 1768
 	AttackMotion: 768
+	DamageDelay: 360
 	DamageMotion: 576
 	Drops: {
 		Yellow_Live: 50
@@ -39613,6 +40374,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1864
 	AttackMotion: 864
+	DamageDelay: 472
 	DamageMotion: 1008
 	Drops: {
 		Acorn: 9000
@@ -39662,6 +40424,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1500
 	AttackMotion: 500
+	DamageDelay: 472
 	DamageMotion: 1000
 	Drops: {
 		Claw_Of_Monkey: 5335
@@ -39707,6 +40470,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1480
 	AttackMotion: 480
+	DamageDelay: 180
 	DamageMotion: 480
 	Drops: {
 		Moustache_Of_Mole: 9000
@@ -39753,6 +40517,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 1120
 	AttackMotion: 552
+	DamageDelay: 708
 	DamageMotion: 0
 	Drops: {
 		Peeps: 5000
@@ -39800,6 +40565,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 676
 	AttackMotion: 648
+	DamageDelay: 405
 	DamageMotion: 432
 	Drops: {
 		Clattering_Skull: 3000
@@ -39851,6 +40617,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1960
 	AttackMotion: 576
+	DamageDelay: 315
 	DamageMotion: 420
 	Drops: {
 		Clattering_Skull: 3000
@@ -39904,6 +40671,7 @@ mob_db: (
 	MoveSpeed: 140
 	AttackDelay: 824
 	AttackMotion: 432
+	DamageDelay: 315
 	DamageMotion: 360
 	Drops: {
 		Monsters_Feed: 5000
@@ -39956,6 +40724,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 676
 	AttackMotion: 504
+	DamageDelay: 405
 	DamageMotion: 504
 	Drops: {
 		Old_White_Cloth: 3000
@@ -40007,6 +40776,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 676
 	AttackMotion: 504
+	DamageDelay: 405
 	DamageMotion: 504
 },
 {
@@ -40047,6 +40817,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 972
 	AttackMotion: 648
+	DamageDelay: 472
 	DamageMotion: 432
 	Drops: {
 		Skull: 5000
@@ -40097,6 +40868,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1816
 	AttackMotion: 1320
+	DamageDelay: 731
 	DamageMotion: 420
 	Drops: {
 		Clattering_Skull: 3000
@@ -40151,6 +40923,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 432
 	AttackMotion: 432
+	DamageDelay: 270
 	DamageMotion: 360
 	DamageTakenRate: 10
 	MvpExp: 1350000
@@ -40211,6 +40984,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 432
 	AttackMotion: 480
+	DamageDelay: 270
 	DamageMotion: 360
 },
 {
@@ -40254,6 +41028,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 100
 	AttackMotion: 576
+	DamageDelay: 236
 	DamageMotion: 480
 },
 {
@@ -40297,6 +41072,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 212
 	AttackMotion: 504
+	DamageDelay: 236
 	DamageMotion: 432
 	DamageTakenRate: 10
 	MvpExp: 3525000
@@ -40355,6 +41131,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 1816
 	AttackMotion: 1152
+	DamageDelay: 450
 	DamageMotion: 360
 	Drops: {
 		Broken_Crown: 9000
@@ -40402,6 +41179,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 1446
 	AttackMotion: 1296
+	DamageDelay: 720
 	DamageMotion: 360
 	MvpExp: 59104
 	MvpDrops: {
@@ -40482,6 +41260,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 1
 	AttackMotion: 1
+	DamageDelay: 2070
 	DamageMotion: 1
 	Drops: {
 		Love_Flower: 3000
@@ -40533,6 +41312,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1456
 	AttackMotion: 456
+	DamageDelay: 247
 	DamageMotion: 336
 },
 // Moscovia
@@ -40570,6 +41350,7 @@ mob_db: (
 	MoveSpeed: 320
 	AttackDelay: 2304
 	AttackMotion: 840
+	DamageDelay: 337
 	DamageMotion: 360
 	Drops: {
 		Iron_Wrist: 5
@@ -40617,6 +41398,7 @@ mob_db: (
 	MoveSpeed: 230
 	AttackDelay: 1728
 	AttackMotion: 720
+	DamageDelay: 393
 	DamageMotion: 576
 	Drops: {
 		Sharp_Leaf: 2000
@@ -40666,6 +41448,7 @@ mob_db: (
 	MoveSpeed: 270
 	AttackDelay: 1536
 	AttackMotion: 600
+	DamageDelay: 393
 	DamageMotion: 420
 	Drops: {
 		Old_Magic_Circle: 1000
@@ -40715,6 +41498,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 576
 	AttackMotion: 672
+	DamageDelay: 450
 	DamageMotion: 384
 	Drops: {
 		Leaflet_Of_Hinal: 900
@@ -40763,6 +41547,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 1536
 	AttackMotion: 504
+	DamageDelay: 360
 	DamageMotion: 360
 	Drops: {
 		Principles_Of_Magic: 5
@@ -40816,6 +41601,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1536
 	AttackMotion: 864
+	DamageDelay: 607
 	DamageMotion: 432
 	DamageTakenRate: 10
 	MvpExp: 357120
@@ -40871,6 +41657,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 1536
 	AttackMotion: 504
+	DamageDelay: 360
 	DamageMotion: 360
 },
 // Additional Monsters
@@ -41089,6 +41876,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 576
 	AttackMotion: 576
+	DamageDelay: 472
 	DamageMotion: 480
 	Drops: {
 	}
@@ -41131,6 +41919,7 @@ mob_db: (
 	MoveSpeed: 125
 	AttackDelay: 747
 	AttackMotion: 1632
+	DamageDelay: 1530
 	DamageMotion: 576
 },
 {
@@ -41173,6 +41962,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1500
 	AttackMotion: 500
+	DamageDelay: 675
 	DamageMotion: 1000
 },
 {
@@ -41213,6 +42003,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1672
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Unknown_Fish: 10000
@@ -41264,6 +42055,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 },
 {
@@ -41305,6 +42097,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1152
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 },
 {
@@ -41348,6 +42141,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 768
 	AttackMotion: 768
+	DamageDelay: 540
 	DamageMotion: 576
 },
 {
@@ -41387,6 +42181,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 2612
 	AttackMotion: 912
+	DamageDelay: 855
 	DamageMotion: 288
 	Drops: {
 		Jade_Plate: 10000
@@ -41503,6 +42298,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1148
 	AttackMotion: 648
+	DamageDelay: 607
 	DamageMotion: 480
 	Drops: {
 		Immortality_Egg: 1000
@@ -41624,6 +42420,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1672
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 },
 {
@@ -41659,6 +42456,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 90
 	DamageMotion: 384
 },
 {
@@ -41695,6 +42493,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 90
 	DamageMotion: 384
 },
 {
@@ -41730,6 +42529,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 90
 	DamageMotion: 384
 },
 {
@@ -41765,6 +42565,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 90
 	DamageMotion: 384
 },
 {
@@ -41801,6 +42602,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 270
 	DamageMotion: 384
 },
 {
@@ -41837,6 +42639,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 270
 	DamageMotion: 384
 },
 {
@@ -41873,6 +42676,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 90
 	DamageMotion: 384
 },
 {
@@ -41909,6 +42713,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 90
 	DamageMotion: 384
 },
 {
@@ -41945,6 +42750,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 90
 	DamageMotion: 384
 },
 {
@@ -41981,6 +42787,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 90
 	DamageMotion: 384
 },
 {
@@ -42017,6 +42824,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 90
 	DamageMotion: 384
 },
 // Dimentional Gorge (12.1)
@@ -42061,6 +42869,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 312
 	AttackMotion: 624
+	DamageDelay: 315
 	DamageMotion: 432
 	Drops: {
 		Diabolus_Helmet: 1500
@@ -42112,6 +42921,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 312
 	AttackMotion: 624
+	DamageDelay: 315
 	DamageMotion: 432
 	DamageTakenRate: 10
 	MvpExp: 2025000
@@ -42170,6 +42980,7 @@ mob_db: (
 	MoveSpeed: 110
 	AttackDelay: 576
 	AttackMotion: 480
+	DamageDelay: 405
 	DamageMotion: 432
 	Drops: {
 		Herald_Of_GOD: 10
@@ -42222,6 +43033,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 576
 	AttackMotion: 648
+	DamageDelay: 337
 	DamageMotion: 300
 	Drops: {
 		Skin_Of_Ventus: 3
@@ -42273,6 +43085,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 212
 	AttackMotion: 432
+	DamageDelay: 202
 	DamageMotion: 360
 	Drops: {
 		Ragamuffin_Cape: 10
@@ -42325,6 +43138,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1536
 	AttackMotion: 648
+	DamageDelay: 405
 	DamageMotion: 300
 	Drops: {
 		Diabolus_Ring: 5
@@ -42377,6 +43191,7 @@ mob_db: (
 	MoveSpeed: 110
 	AttackDelay: 312
 	AttackMotion: 480
+	DamageDelay: 405
 	DamageMotion: 432
 },
 {
@@ -42421,6 +43236,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 312
 	AttackMotion: 648
+	DamageDelay: 337
 	DamageMotion: 300
 },
 {
@@ -42465,6 +43281,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 212
 	AttackMotion: 432
+	DamageDelay: 202
 	DamageMotion: 360
 },
 {
@@ -42509,6 +43326,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1536
 	AttackMotion: 648
+	DamageDelay: 405
 	DamageMotion: 300
 },
 // God Item Creation (WoE SE); Catacombs
@@ -42698,6 +43516,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 768
 	AttackMotion: 768
+	DamageDelay: 360
 	DamageMotion: 576
 	Drops: {
 		Bapho_Doll: 500
@@ -42751,6 +43570,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 432
 	AttackMotion: 768
+	DamageDelay: 270
 	DamageMotion: 576
 },
 {
@@ -42794,6 +43614,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 576
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 480
 },
 {
@@ -42831,6 +43652,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 768
 	AttackMotion: 768
+	DamageDelay: 270
 	DamageMotion: 576
 	Drops: {
 		Crystal_Key: 9000
@@ -42877,6 +43699,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 432
 	AttackMotion: 480
+	DamageDelay: 337
 	DamageMotion: 360
 },
 {
@@ -42912,6 +43735,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 768
 	AttackMotion: 768
+	DamageDelay: 90
 	DamageMotion: 576
 },
 {
@@ -42947,6 +43771,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 768
 	AttackMotion: 768
+	DamageDelay: 90
 	DamageMotion: 576
 },
 {
@@ -42982,6 +43807,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 768
 	AttackMotion: 768
+	DamageDelay: 90
 	DamageMotion: 576
 },
 {
@@ -43021,6 +43847,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 720
 	AttackMotion: 360
+	DamageDelay: 337
 	DamageMotion: 360
 },
 {
@@ -43469,6 +44296,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 432
 	AttackMotion: 768
+	DamageDelay: 270
 	DamageMotion: 576
 },
 {
@@ -43508,6 +44336,7 @@ mob_db: (
 	MoveSpeed: 145
 	AttackDelay: 576
 	AttackMotion: 432
+	DamageDelay: 270
 	DamageMotion: 288
 },
 // Battlegrounds Guardians
@@ -43857,6 +44686,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 432
+	DamageDelay: 315
 	DamageMotion: 504
 	Drops: {
 		Twin_Edge_B: 9000
@@ -43904,6 +44734,7 @@ mob_db: (
 	MoveSpeed: 0
 	AttackDelay: 140
 	AttackMotion: 540
+	DamageDelay: 506
 	DamageMotion: 576
 	Drops: {
 		Thorn_Staff: 9000
@@ -44099,6 +44930,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 720
 	AttackMotion: 720
+	DamageDelay: 405
 	DamageMotion: 432
 },
 {
@@ -44140,6 +44972,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 1728
 	AttackMotion: 816
+	DamageDelay: 225
 	DamageMotion: 1188
 },
 {
@@ -44215,6 +45048,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 964
 	AttackMotion: 864
+	DamageDelay: 787
 	DamageMotion: 288
 },
 {
@@ -44250,6 +45084,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 300
 	AttackMotion: 480
+	DamageDelay: 180
 	DamageMotion: 288
 },
 {
@@ -44286,6 +45121,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 300
 	AttackMotion: 480
+	DamageDelay: 270
 	DamageMotion: 288
 },
 {
@@ -44321,6 +45157,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 101
 	DamageMotion: 384
 	Drops: {
 		Fin: 5335
@@ -44366,6 +45203,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1272
 	AttackMotion: 72
+	DamageDelay: 202
 	DamageMotion: 480
 	Drops: {
 		Mistic_Frozen: 36
@@ -44412,6 +45250,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 360
 	DamageMotion: 288
 	Drops: {
 		Mistic_Frozen: 26
@@ -44457,6 +45296,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1632
 	AttackMotion: 432
+	DamageDelay: 393
 	DamageMotion: 540
 	Drops: {
 		Crystal_Blue: 40
@@ -44502,6 +45342,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 2280
 	AttackMotion: 1080
+	DamageDelay: 675
 	DamageMotion: 864
 	Drops: {
 		Single_Cell: 5000
@@ -44546,6 +45387,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Gift_Box: 10000
@@ -44596,6 +45438,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 676
 	AttackMotion: 504
+	DamageDelay: 405
 	DamageMotion: 504
 	Drops: {
 		Old_White_Cloth: 3000
@@ -44645,6 +45488,7 @@ mob_db: (
 	MoveSpeed: 190
 	AttackDelay: 336
 	AttackMotion: 840
+	DamageDelay: 225
 	DamageMotion: 360
 	Drops: {
 		Prickly_Fruit: 3000
@@ -44694,6 +45538,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 648
 	AttackMotion: 480
+	DamageDelay: 337
 	DamageMotion: 360
 	Drops: {
 		Fragment_Of_Crystal: 3000
@@ -44743,6 +45588,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 384
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Tube: 4000
@@ -44793,6 +45639,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1840
 	AttackMotion: 1440
+	DamageDelay: 495
 	DamageMotion: 384
 	Drops: {
 		Broken_Steel_Piece: 5335
@@ -44843,6 +45690,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 580
 	AttackMotion: 288
+	DamageDelay: 225
 	DamageMotion: 360
 	Drops: {
 		Screw: 5000
@@ -44897,6 +45745,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 964
 	AttackMotion: 648
+	DamageDelay: 337
 	DamageMotion: 300
 	MvpExp: 45000
 	MvpDrops: {
@@ -44952,6 +45801,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1500
 	AttackMotion: 500
+	DamageDelay: 405
 	DamageMotion: 1000
 },
 {
@@ -44992,6 +45842,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1960
 	AttackMotion: 620
+	DamageDelay: 810
 	DamageMotion: 480
 },
 {
@@ -45032,6 +45883,7 @@ mob_db: (
 	MoveSpeed: 130
 	AttackDelay: 2420
 	AttackMotion: 720
+	DamageDelay: 270
 	DamageMotion: 648
 },
 {
@@ -45074,6 +45926,7 @@ mob_db: (
 	MoveSpeed: 145
 	AttackDelay: 1050
 	AttackMotion: 900
+	DamageDelay: 506
 	DamageMotion: 288
 },
 // Another World (13.1)
@@ -45116,6 +45969,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1772
 	AttackMotion: 72
+	DamageDelay: 472
 	DamageMotion: 384
 },
 {
@@ -45154,6 +46008,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1000
 	AttackMotion: 768
+	DamageDelay: 450
 	DamageMotion: 360
 	Drops: {
 		Lunakaligo: 20
@@ -45206,6 +46061,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1000
 	AttackMotion: 792
+	DamageDelay: 540
 	DamageMotion: 336
 	Drops: {
 		Cold_Heart: 2
@@ -45251,6 +46107,7 @@ mob_db: (
 	MoveSpeed: 1000
 	AttackDelay: 500
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 504
 	Drops: {
 		Mandragora_Cap: 1
@@ -45300,6 +46157,7 @@ mob_db: (
 	MoveSpeed: 130
 	AttackDelay: 400
 	AttackMotion: 780
+	DamageDelay: 450
 	DamageMotion: 576
 	Drops: {
 		Sprint_Shoes: 10
@@ -45353,6 +46211,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1000
 	AttackMotion: 660
+	DamageDelay: 281
 	DamageMotion: 588
 	Drops: {
 		Bone_Head: 100
@@ -45406,6 +46265,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 500
 	AttackMotion: 960
+	DamageDelay: 731
 	DamageMotion: 360
 	Drops: {
 		Leather_Of_Tendrilion: 500
@@ -45453,6 +46313,7 @@ mob_db: (
 	MoveSpeed: 120
 	AttackDelay: 1000
 	AttackMotion: 624
+	DamageDelay: 180
 	DamageMotion: 300
 	Drops: {
 		Sprint_Mail: 10
@@ -45504,6 +46365,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 400
 	AttackMotion: 864
+	DamageDelay: 675
 	DamageMotion: 432
 	Drops: {
 		Armor_Of_Naga: 10
@@ -45557,6 +46419,7 @@ mob_db: (
 	MoveSpeed: 110
 	AttackDelay: 1000
 	AttackMotion: 864
+	DamageDelay: 675
 	DamageMotion: 432
 	Drops: {
 		Sprint_Ring: 2
@@ -45606,6 +46469,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 700
 	AttackMotion: 600
+	DamageDelay: 281
 	DamageMotion: 360
 	Drops: {
 		Pinguicula_Corsage: 1
@@ -45702,6 +46566,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1000
 	AttackMotion: 768
+	DamageDelay: 450
 	DamageMotion: 360
 },
 {
@@ -45741,6 +46606,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 400
 	AttackMotion: 780
+	DamageDelay: 450
 	DamageMotion: 576
 },
 {
@@ -45783,6 +46649,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1000
 	AttackMotion: 792
+	DamageDelay: 540
 	DamageMotion: 336
 	Drops: {
 		Boots_: 9
@@ -45828,6 +46695,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 300
 	AttackMotion: 384
+	DamageDelay: 360
 	DamageMotion: 288
 },
 {
@@ -45863,6 +46731,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 300
 	AttackMotion: 384
+	DamageDelay: 360
 	DamageMotion: 288
 },
 {
@@ -45899,6 +46768,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 1120
 	AttackMotion: 552
+	DamageDelay: 708
 	DamageMotion: 0
 	Drops: {
 		Magical_Moon_Cake: 1000
@@ -45945,6 +46815,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 576
 	AttackMotion: 960
+	DamageDelay: 900
 	DamageMotion: 480
 	Drops: {
 		Moon_Cake1: 1000
@@ -45995,6 +46866,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 637
 	AttackMotion: 1008
+	DamageDelay: 540
 	DamageMotion: 360
 	Drops: {
 		Moon_Cake1: 800
@@ -46043,6 +46915,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 608
 	AttackMotion: 1440
+	DamageDelay: 1215
 	DamageMotion: 576
 	Drops: {
 		Moon_Cake1: 500
@@ -46089,6 +46962,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 608
 	AttackMotion: 1440
+	DamageDelay: 1215
 	DamageMotion: 576
 	Drops: {
 		Moon_Cake15: 500
@@ -46135,6 +47009,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 608
 	AttackMotion: 1440
+	DamageDelay: 1215
 	DamageMotion: 576
 	Drops: {
 		Moon_Cake1: 500
@@ -46267,6 +47142,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1100
 	AttackMotion: 960
+	DamageDelay: 1800
 	DamageMotion: 780
 },
 {
@@ -46306,6 +47182,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 2456
 	AttackMotion: 912
+	DamageDelay: 427
 	DamageMotion: 504
 	Drops: {
 		Horrendous_Mouth: 6000
@@ -46353,6 +47230,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 2612
 	AttackMotion: 912
+	DamageDelay: 855
 	DamageMotion: 288
 	Drops: {
 		Decayed_Nail: 9000
@@ -46399,6 +47277,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 576
 	AttackMotion: 960
+	DamageDelay: 393
 	DamageMotion: 504
 	Drops: {
 		Dragons_Mane: 3000
@@ -46440,6 +47319,7 @@ mob_db: (
 	MoveSpeed: 1000
 	AttackDelay: 24
 	AttackMotion: 0
+	DamageDelay: 22
 	DamageMotion: 0
 	Drops: {
 		Piece_Of_Egg_Shell: 5000
@@ -46484,6 +47364,7 @@ mob_db: (
 	MoveSpeed: 290
 	AttackDelay: 1426
 	AttackMotion: 600
+	DamageDelay: 337
 	DamageMotion: 360
 	Drops: {
 		Sharp_Leaf: 5000
@@ -46533,6 +47414,7 @@ mob_db: (
 	MoveSpeed: 230
 	AttackDelay: 504
 	AttackMotion: 960
+	DamageDelay: 450
 	DamageMotion: 576
 	Drops: {
 		Crystalized_Teardrop: 1000
@@ -46581,6 +47463,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 792
 	AttackMotion: 540
+	DamageDelay: 393
 	DamageMotion: 420
 	Drops: {
 		Unripe_Acorn: 5000
@@ -46629,6 +47512,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 672
 	AttackMotion: 420
+	DamageDelay: 281
 	DamageMotion: 360
 	Drops: {
 		Carrot: 5000
@@ -46678,6 +47562,7 @@ mob_db: (
 	MoveSpeed: 290
 	AttackDelay: 504
 	AttackMotion: 960
+	DamageDelay: 450
 	DamageMotion: 576
 	Drops: {
 		Tough_Vines: 1000
@@ -46726,6 +47611,7 @@ mob_db: (
 	MoveSpeed: 240
 	AttackDelay: 576
 	AttackMotion: 660
+	DamageDelay: 281
 	DamageMotion: 420
 	Drops: {
 		Fluorescent_Liquid: 5000
@@ -46769,6 +47655,7 @@ mob_db: (
 	MoveSpeed: 240
 	AttackDelay: 360
 	AttackMotion: 780
+	DamageDelay: 506
 	DamageMotion: 432
 	Drops: {
 		Fluorescent_Liquid: 5000
@@ -46819,6 +47706,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1596
 	AttackMotion: 1620
+	DamageDelay: 540
 	DamageMotion: 864
 	MvpExp: 2160000
 	MvpDrops: {
@@ -46875,6 +47763,7 @@ mob_db: (
 	MoveSpeed: 220
 	AttackDelay: 768
 	AttackMotion: 1776
+	DamageDelay: 855
 	DamageMotion: 648
 	Drops: {
 		Piece_Of_Black_Cloth: 5000
@@ -46925,6 +47814,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1008
 	AttackMotion: 1200
+	DamageDelay: 450
 	DamageMotion: 540
 	Drops: {
 		Stone_Piece: 3000
@@ -47020,6 +47910,7 @@ mob_db: (
 	MoveSpeed: 230
 	AttackDelay: 1772
 	AttackMotion: 72
+	DamageDelay: 472
 	DamageMotion: 384
 	Drops: {
 		Old_Frying_Pan: 5000
@@ -47072,6 +47963,7 @@ mob_db: (
 	MoveSpeed: 220
 	AttackDelay: 768
 	AttackMotion: 1776
+	DamageDelay: 855
 	DamageMotion: 648
 },
 // Additional Monsters
@@ -47358,6 +48250,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1600
 	AttackMotion: 900
+	DamageDelay: 236
 	DamageMotion: 240
 },
 {
@@ -47393,6 +48286,7 @@ mob_db: (
 	MoveSpeed: 1000
 	AttackDelay: 1001
 	AttackMotion: 1
+	DamageDelay: 90
 	DamageMotion: 1
 },
 {
@@ -47871,6 +48765,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 400
 	AttackMotion: 864
+	DamageDelay: 675
 	DamageMotion: 432
 	Drops: {
 		Scale_Of_Snakes: 5000
@@ -47913,6 +48808,7 @@ mob_db: (
 	MoveSpeed: 290
 	AttackDelay: 1426
 	AttackMotion: 600
+	DamageDelay: 337
 	DamageMotion: 360
 	Drops: {
 		Withered_Flower: 1000
@@ -47956,6 +48852,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1008
 	AttackMotion: 1200
+	DamageDelay: 450
 	DamageMotion: 540
 	Drops: {
 		Purified_Bradium: 500
@@ -47998,6 +48895,7 @@ mob_db: (
 	MoveSpeed: 230
 	AttackDelay: 504
 	AttackMotion: 960
+	DamageDelay: 450
 	DamageMotion: 576
 	Drops: {
 		Tiny_Waterbottle: 100
@@ -48044,6 +48942,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 768
 	AttackMotion: 768
+	DamageDelay: 540
 	DamageMotion: 576
 	Drops: {
 		Fools_Day_Box: 5000
@@ -48135,6 +49034,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 576
 	AttackMotion: 720
+	DamageDelay: 315
 	DamageMotion: 432
 	Drops: {
 		Old_Steel_Plate: 2000
@@ -48307,6 +49207,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1000
 	AttackMotion: 500
+	DamageDelay: 607
 	DamageMotion: 1000
 },
 {
@@ -48346,6 +49247,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 972
 	AttackMotion: 500
+	DamageDelay: 450
 	DamageMotion: 288
 },
 {
@@ -48385,6 +49287,7 @@ mob_db: (
 	MoveSpeed: 147
 	AttackDelay: 516
 	AttackMotion: 768
+	DamageDelay: 337
 	DamageMotion: 384
 },
 {
@@ -48421,6 +49324,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 502
 	AttackMotion: 1999
+	DamageDelay: 2160
 	DamageMotion: 480
 },
 /*{
@@ -48693,6 +49597,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 1084
 	AttackMotion: 2304
+	DamageDelay: 360
 	DamageMotion: 576
 	MvpDrops: {
 		Mosquito_Coil: 10000
@@ -48735,6 +49640,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 1084
 	AttackMotion: 2304
+	DamageDelay: 360
 	DamageMotion: 576
 	Drops: {
 		Wing_Of_Fly: 1000
@@ -48784,6 +49690,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1152
 	AttackMotion: 1152
+	DamageDelay: 225
 	DamageMotion: 576
 	DamageTakenRate: 10
 	MvpExp: 37144
@@ -48836,6 +49743,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 384
 	AttackMotion: 672
+	DamageDelay: 360
 	DamageMotion: 288
 	Drops: {
 		Mistic_Frozen: 5
@@ -48884,6 +49792,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 768
 	AttackMotion: 480
+	DamageDelay: 270
 	DamageMotion: 864
 	Drops: {
 		Gill: 600
@@ -48933,6 +49842,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1216
 	AttackMotion: 816
+	DamageDelay: 270
 	DamageMotion: 432
 	Drops: {
 		Burning_Horse_Shoe: 4000
@@ -48978,6 +49888,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 576
 	AttackMotion: 1248
+	DamageDelay: 405
 	DamageMotion: 480
 	Drops: {
 		Leopard_Skin: 3000
@@ -49022,6 +49933,7 @@ mob_db: (
 	MoveSpeed: 155
 	AttackDelay: 960
 	AttackMotion: 1440
+	DamageDelay: 281
 	DamageMotion: 960
 	Drops: {
 		Talon: 3000
@@ -49068,6 +49980,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 528
 	AttackMotion: 480
+	DamageDelay: 180
 	DamageMotion: 384
 	Drops: {
 		Meat: 3000
@@ -49111,6 +50024,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1632
 	AttackMotion: 432
+	DamageDelay: 393
 	DamageMotion: 540
 	Drops: {
 		Nipper: 5000
@@ -49164,6 +50078,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1056
 	AttackMotion: 1056
+	DamageDelay: 675
 	DamageMotion: 336
 },
 {
@@ -49205,6 +50120,7 @@ mob_db: (
 	MoveSpeed: 190
 	AttackDelay: 720
 	AttackMotion: 384
+	DamageDelay: 337
 	DamageMotion: 480
 },
 {
@@ -49247,6 +50163,7 @@ mob_db: (
 	MoveSpeed: 155
 	AttackDelay: 1306
 	AttackMotion: 1056
+	DamageDelay: 540
 	DamageMotion: 288
 },
 {
@@ -49288,6 +50205,7 @@ mob_db: (
 	MoveSpeed: 177
 	AttackDelay: 1152
 	AttackMotion: 1152
+	DamageDelay: 1080
 	DamageMotion: 288
 },
 {
@@ -49329,6 +50247,7 @@ mob_db: (
 	MoveSpeed: 177
 	AttackDelay: 0
 	AttackMotion: 0
+	DamageDelay: 1080
 	DamageMotion: 0
 },
 {
@@ -49361,6 +50280,7 @@ mob_db: (
 	MoveSpeed: 1000
 	AttackDelay: 800
 	AttackMotion: 432
+	DamageDelay: 315
 	DamageMotion: 600
 },
 {
@@ -49401,6 +50321,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 768
 	AttackMotion: 480
+	DamageDelay: 270
 	DamageMotion: 864
 },
 // El Dicastes (13.3)
@@ -49441,6 +50362,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 384
 	AttackMotion: 672
+	DamageDelay: 337
 	DamageMotion: 360
 	Drops: {
 		Singlehorn_Helm: 6500
@@ -49488,6 +50410,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 336
 	AttackMotion: 360
+	DamageDelay: 225
 	DamageMotion: 360
 	Drops: {
 		Twinhorn_Helm: 6500
@@ -49536,6 +50459,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 504
 	AttackMotion: 624
+	DamageDelay: 450
 	DamageMotion: 360
 	Drops: {
 		Antler_Helm: 6500
@@ -49584,6 +50508,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 588
 	AttackMotion: 768
+	DamageDelay: 393
 	DamageMotion: 480
 	Drops: {
 		Rakehorn_Helm: 6500
@@ -49635,6 +50560,7 @@ mob_db: (
 	MoveSpeed: 120
 	AttackDelay: 864
 	AttackMotion: 1000
+	DamageDelay: 281
 	DamageMotion: 360
 	DamageTakenRate: 10
 	MvpExp: 205110
@@ -49685,6 +50611,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 96
 	AttackMotion: 1
+	DamageDelay: 90
 	DamageMotion: 480
 	Drops: {
 		Piece_Of_Egg_Shell: 5000
@@ -49725,6 +50652,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 96
 	AttackMotion: 1
+	DamageDelay: 90
 	DamageMotion: 480
 	Drops: {
 		Piece_Of_Egg_Shell: 5000
@@ -49764,6 +50692,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 96
 	AttackMotion: 1
+	DamageDelay: 90
 	DamageMotion: 480
 	Drops: {
 		Piece_Of_Egg_Shell: 5000
@@ -49803,6 +50732,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 96
 	AttackMotion: 1
+	DamageDelay: 90
 	DamageMotion: 480
 	Drops: {
 		Piece_Of_Egg_Shell: 5000
@@ -49849,6 +50779,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 360
 	AttackMotion: 360
+	DamageDelay: 281
 	DamageMotion: 600
 	Drops: {
 		Small_Bradium: 3000
@@ -49894,6 +50825,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 225
 	DamageMotion: 480
 	Drops: {
 		Crumpled_Paper: 7000
@@ -49948,6 +50880,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1678
 	AttackMotion: 780
+	DamageDelay: 731
 	DamageMotion: 648
 	MvpExp: 1005
 	MvpDrops: {
@@ -50007,6 +50940,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 872
 	AttackMotion: 1344
+	DamageDelay: 382
 	DamageMotion: 432
 	MvpExp: 1005
 	MvpDrops: {
@@ -50125,6 +51059,7 @@ mob_db: (
 	MoveSpeed: 145
 	AttackDelay: 1290
 	AttackMotion: 1140
+	DamageDelay: 731
 	DamageMotion: 576
 	MvpExp: 1005
 	MvpDrops: {
@@ -50184,6 +51119,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 480
 	AttackMotion: 480
+	DamageDelay: 180
 	DamageMotion: 288
 	MvpExp: 1005
 	MvpDrops: {
@@ -50241,6 +51177,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1148
 	AttackMotion: 648
+	DamageDelay: 607
 	DamageMotion: 300
 	MvpExp: 1005
 	MvpDrops: {
@@ -50300,6 +51237,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 768
 	AttackMotion: 768
+	DamageDelay: 360
 	DamageMotion: 576
 	MvpExp: 1005
 	MvpDrops: {
@@ -50419,6 +51357,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 868
 	AttackMotion: 768
+	DamageDelay: 382
 	DamageMotion: 480
 	MvpDrops: {
 		Skull: 6000
@@ -50477,6 +51416,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 432
 	AttackMotion: 840
+	DamageDelay: 618
 	DamageMotion: 216
 	MvpExp: 1005
 	MvpDrops: {
@@ -50537,6 +51477,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 588
 	AttackMotion: 816
+	DamageDelay: 1530
 	DamageMotion: 420
 	MvpExp: 1005
 	MvpDrops: {
@@ -50596,6 +51537,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 900
 	AttackMotion: 1000
+	DamageDelay: 585
 	DamageMotion: 500
 	MvpExp: 1005
 	MvpDrops: {
@@ -50655,6 +51597,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 504
 	AttackMotion: 912
+	DamageDelay: 495
 	DamageMotion: 432
 	DamageTakenRate: 10
 	MvpExp: 1005
@@ -50715,6 +51658,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 432
 	AttackMotion: 432
+	DamageDelay: 270
 	DamageMotion: 360
 	MvpExp: 1005
 	MvpDrops: {
@@ -50774,6 +51718,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1344
 	AttackMotion: 2880
+	DamageDelay: 270
 	DamageMotion: 576
 	MvpExp: 1005
 	MvpDrops: {
@@ -50833,6 +51778,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 576
 	AttackMotion: 576
+	DamageDelay: 472
 	DamageMotion: 480
 	MvpExp: 1005
 	MvpDrops: {
@@ -50892,6 +51838,7 @@ mob_db: (
 	MoveSpeed: 130
 	AttackDelay: 212
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 360
 	MvpExp: 1005
 	MvpDrops: {
@@ -50952,6 +51899,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 225
 	DamageMotion: 288
 	MvpExp: 1005
 	MvpDrops: {
@@ -51011,6 +51959,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	MvpExp: 1005
 	MvpDrops: {
@@ -51069,6 +52018,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	MvpExp: 1005
 	MvpDrops: {
@@ -51748,6 +52698,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 840
 	AttackMotion: 648
+	DamageDelay: 405
 	DamageMotion: 576
 	MvpDrops: {
 		Old_Card_Album: 500
@@ -51801,6 +52752,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 864
 	AttackMotion: 1056
+	DamageDelay: 337
 	DamageMotion: 576
 	Drops: {
 		Fruit_Basket: 500
@@ -51849,6 +52801,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 576
 	AttackMotion: 480
+	DamageDelay: 315
 	DamageMotion: 480
 	Drops: {
 		Withered_Flower: 3000
@@ -51894,6 +52847,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 384
 	AttackMotion: 792
+	DamageDelay: 337
 	DamageMotion: 432
 	Drops: {
 		Round_Feather: 3000
@@ -51937,6 +52891,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 192
 	AttackMotion: 192
+	DamageDelay: 180
 	DamageMotion: 576
 },
 {
@@ -51976,6 +52931,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 432
 	AttackMotion: 300
+	DamageDelay: 225
 	DamageMotion: 432
 	Drops: {
 		Angel_Magic_Power: 3000
@@ -52022,6 +52978,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 576
 	AttackMotion: 1140
+	DamageDelay: 225
 	DamageMotion: 504
 	Drops: {
 		Golden_Feather: 3000
@@ -52067,6 +53024,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1248
 	AttackMotion: 576
+	DamageDelay: 720
 	DamageMotion: 1248
 },
 {
@@ -52105,6 +53063,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1248
 	AttackMotion: 576
+	DamageDelay: 1170
 	DamageMotion: 1248
 },
 {
@@ -52297,6 +53256,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 504
 	AttackMotion: 624
+	DamageDelay: 450
 	DamageMotion: 360
 },
 {
@@ -52337,6 +53297,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 588
 	AttackMotion: 768
+	DamageDelay: 393
 	DamageMotion: 480
 },
 {
@@ -52381,6 +53342,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1596
 	AttackMotion: 1620
+	DamageDelay: 540
 	DamageMotion: 864
 },
 {
@@ -52417,6 +53379,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 1080
 	DamageMotion: 480
 },
 {
@@ -52453,6 +53416,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 1080
 	DamageMotion: 480
 },
 {
@@ -52489,6 +53453,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 292
 	DamageMotion: 480
 },
 {
@@ -52524,6 +53489,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 96
 	AttackMotion: 96
+	DamageDelay: 0
 	DamageMotion: 96
 	Drops: {
 		Stem: 3000
@@ -52572,6 +53538,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 500
 	AttackMotion: 576
+	DamageDelay: 337
 	DamageMotion: 504
 	Drops: {
 		Clover: 250
@@ -52620,6 +53587,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 500
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 504
 	Drops: {
 		Comodo_L: 5000
@@ -52666,6 +53634,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 576
 	AttackMotion: 720
+	DamageDelay: 202
 	DamageMotion: 360
 	Drops: {
 		Cendrawasih_F: 9000
@@ -52711,6 +53680,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1152
 	AttackMotion: 2304
+	DamageDelay: 1012
 	DamageMotion: 432
 	Drops: {
 		Coal: 1000
@@ -52758,6 +53728,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 576
 	AttackMotion: 768
+	DamageDelay: 315
 	DamageMotion: 432
 	Drops: {
 		Sticky_Mucus: 2750
@@ -52807,6 +53778,7 @@ mob_db: (
 	MoveSpeed: 130
 	AttackDelay: 576
 	AttackMotion: 576
+	DamageDelay: 540
 	DamageMotion: 360
 	DamageTakenRate: 10
 	MvpDrops: {
@@ -52860,6 +53832,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 0
 	AttackMotion: 0
+	DamageDelay: 1012
 	DamageMotion: 0
 },
 // Homunculus S Summons
@@ -52897,6 +53870,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1292
 	AttackMotion: 792
+	DamageDelay: 742
 	DamageMotion: 216
 },
 {
@@ -52933,6 +53907,7 @@ mob_db: (
 	MoveSpeed: 155
 	AttackDelay: 1292
 	AttackMotion: 792
+	DamageDelay: 742
 	DamageMotion: 340
 },
 {
@@ -52969,6 +53944,7 @@ mob_db: (
 	MoveSpeed: 110
 	AttackDelay: 1000
 	AttackMotion: 864
+	DamageDelay: 675
 	DamageMotion: 432
 },
 // Nightmare Scaraba Hole
@@ -53012,6 +53988,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 384
 	AttackMotion: 672
+	DamageDelay: 337
 	DamageMotion: 360
 	Drops: {
 		Singlehorn_Helm: 6500
@@ -53064,6 +54041,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 336
 	AttackMotion: 360
+	DamageDelay: 225
 	DamageMotion: 360
 	Drops: {
 		Twinhorn_Helm: 6500
@@ -53115,6 +54093,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 504
 	AttackMotion: 624
+	DamageDelay: 393
 	DamageMotion: 360
 	Drops: {
 		Antler_Helm: 6500
@@ -53166,6 +54145,7 @@ mob_db: (
 	MoveSpeed: 140
 	AttackDelay: 588
 	AttackMotion: 768
+	DamageDelay: 1170
 	DamageMotion: 480
 	Drops: {
 		Rakehorn_Helm: 6500
@@ -53219,6 +54199,7 @@ mob_db: (
 	MoveSpeed: 120
 	AttackDelay: 864
 	AttackMotion: 1000
+	DamageDelay: 281
 	DamageMotion: 360
 	DamageTakenRate: 10
 	MvpDrops: {
@@ -53268,6 +54249,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 96
 	AttackMotion: 1
+	DamageDelay: 90
 	DamageMotion: 480
 	Drops: {
 		Piece_Of_Egg_Shell: 5000
@@ -53306,6 +54288,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 96
 	AttackMotion: 1
+	DamageDelay: 90
 	DamageMotion: 480
 	Drops: {
 		Piece_Of_Egg_Shell: 5000
@@ -53343,6 +54326,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 96
 	AttackMotion: 1
+	DamageDelay: 90
 	DamageMotion: 480
 	Drops: {
 		Piece_Of_Egg_Shell: 5000
@@ -53380,6 +54364,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 96
 	AttackMotion: 1
+	DamageDelay: 90
 	DamageMotion: 480
 	Drops: {
 		Piece_Of_Egg_Shell: 5000
@@ -53428,6 +54413,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 504
 	AttackMotion: 624
+	DamageDelay: 450
 	DamageMotion: 360
 },
 {
@@ -53469,6 +54455,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 588
 	AttackMotion: 768
+	DamageDelay: 393
 	DamageMotion: 480
 },
 {
@@ -53511,6 +54498,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 384
 	AttackMotion: 672
+	DamageDelay: 337
 	DamageMotion: 360
 },
 {
@@ -53553,6 +54541,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 336
 	AttackMotion: 360
+	DamageDelay: 225
 	DamageMotion: 360
 },
 // Malangdo Island
@@ -53597,6 +54586,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1632
 	AttackMotion: 432
+	DamageDelay: 393
 	DamageMotion: 540
 	Drops: {
 		Crystal_Blue: 40
@@ -53648,6 +54638,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1956
 	AttackMotion: 756
+	DamageDelay: 438
 	DamageMotion: 528
 	Drops: {
 		Chinese_Ink: 9000
@@ -53699,6 +54690,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 992
 	AttackMotion: 792
+	DamageDelay: 270
 	DamageMotion: 360
 	Drops: {
 		Crap_Shell: 5500
@@ -53749,6 +54741,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1248
 	AttackMotion: 48
+	DamageDelay: 180
 	DamageMotion: 480
 	Drops: {
 		Crystal_Blue: 46
@@ -53800,6 +54793,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 864
 	AttackMotion: 864
+	DamageDelay: 438
 	DamageMotion: 384
 	Drops: {
 		Clam_Shell: 5500
@@ -53851,6 +54845,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1776
 	AttackMotion: 576
+	DamageDelay: 540
 	DamageMotion: 288
 	Drops: {
 		Crystal_Blue: 30
@@ -53902,6 +54897,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 101
 	DamageMotion: 384
 	Drops: {
 		Fin: 5336
@@ -53953,6 +54949,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1968
 	AttackMotion: 768
+	DamageDelay: 180
 	DamageMotion: 384
 	Drops: {
 		Mistic_Frozen: 10
@@ -54004,6 +55001,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1272
 	AttackMotion: 72
+	DamageDelay: 202
 	DamageMotion: 480
 	Drops: {
 		Mistic_Frozen: 18
@@ -54055,6 +55053,7 @@ mob_db: (
 	MoveSpeed: 190
 	AttackDelay: 900
 	AttackMotion: 500
+	DamageDelay: 618
 	DamageMotion: 864
 	Drops: {
 		Anolian_Skin: 4850
@@ -54106,6 +55105,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 360
 	DamageMotion: 288
 	Drops: {
 		Mistic_Frozen: 14
@@ -54157,6 +55157,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 2012
 	AttackMotion: 1728
+	DamageDelay: 540
 	DamageMotion: 672
 	Drops: {
 		Yellow_Plate: 6500
@@ -54469,6 +55470,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 384
 	AttackMotion: 720
+	DamageDelay: 225
 	DamageMotion: 360
 },
 {
@@ -54511,6 +55513,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 576
 	AttackMotion: 2160
+	DamageDelay: 2025
 	DamageMotion: 504
 	Drops: {
 		Chinese_Ink: 5000
@@ -54554,6 +55557,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 432
 	AttackMotion: 720
+	DamageDelay: 135
 	DamageMotion: 360
 	Drops: {
 		Chinese_Ink: 9000
@@ -54603,6 +55607,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 576
 	AttackMotion: 1584
+	DamageDelay: 236
 	DamageMotion: 360
 	Drops: {
 		Bgrade_Pocket: 3000
@@ -54653,6 +55658,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1776
 	AttackMotion: 576
+	DamageDelay: 540
 	DamageMotion: 288
 },
 {
@@ -54695,6 +55701,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 101
 	DamageMotion: 384
 },
 {
@@ -54732,6 +55739,7 @@ mob_db: (
 	MoveSpeed: 140
 	AttackDelay: 768
 	AttackMotion: 1224
+	DamageDelay: 393
 	DamageMotion: 432
 	Drops: {
 		Clam_Shell: 5000
@@ -54785,6 +55793,7 @@ mob_db: (
 	MoveSpeed: 140
 	AttackDelay: 576
 	AttackMotion: 720
+	DamageDelay: 337
 	DamageMotion: 720
 	Drops: {
 		Ice_Fragment: 100
@@ -54831,6 +55840,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1536
 	AttackMotion: 1296
+	DamageDelay: 225
 	DamageMotion: 576
 	Drops: {
 		Delicious_Jelly: 1400
@@ -54921,6 +55931,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 768
 	AttackMotion: 792
+	DamageDelay: 337
 	DamageMotion: 432
 	Drops: {
 		Fin: 5000
@@ -54974,6 +55985,7 @@ mob_db: (
 	MoveSpeed: 130
 	AttackDelay: 432
 	AttackMotion: 864
+	DamageDelay: 450
 	DamageMotion: 360
 	DamageTakenRate: 10
 	MvpExp: 491666
@@ -55029,6 +56041,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 1008
 	AttackMotion: 936
+	DamageDelay: 877
 	DamageMotion: 432
 	Drops: {
 		Ice_Crystal: 10
@@ -55082,6 +56095,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 768
 	AttackMotion: 792
+	DamageDelay: 270
 	DamageMotion: 432
 	Drops: {
 		Tentacle: 5000
@@ -55172,6 +56186,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 576
 	AttackMotion: 864
+	DamageDelay: 270
 	DamageMotion: 240
 	Drops: {
 		Sticky_Poison: 2
@@ -55255,6 +56270,7 @@ mob_db: (
 	MoveSpeed: 120
 	AttackDelay: 432
 	AttackMotion: 792
+	DamageDelay: 742
 	DamageMotion: 360
 	Drops: {
 		Delicious_Jelly: 5000
@@ -55302,6 +56318,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 720
 	DamageMotion: 768
 },
 {
@@ -55339,6 +56356,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1456
 	AttackMotion: 456
+	DamageDelay: 247
 	DamageMotion: 336
 },
 {
@@ -55376,6 +56394,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 512
 	AttackMotion: 780
+	DamageDelay: 562
 	DamageMotion: 504
 	Drops: {
 		Old_Blue_Box: 1000
@@ -55422,6 +56441,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 236
 	DamageMotion: 480
 },
 {
@@ -55459,6 +56479,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 672
 	AttackMotion: 500
+	DamageDelay: 630
 	DamageMotion: 192
 },
 {
@@ -55496,6 +56517,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 637
 	AttackMotion: 1008
+	DamageDelay: 540
 	DamageMotion: 360
 },
 {
@@ -55532,6 +56554,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 800
 	AttackMotion: 600
+	DamageDelay: 506
 	DamageMotion: 288
 },
 {
@@ -55568,6 +56591,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 140
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 },
 {
@@ -55604,6 +56628,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 512
 	AttackMotion: 780
+	DamageDelay: 562
 	DamageMotion: 504
 },
 {
@@ -55714,6 +56739,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 912
 	AttackMotion: 1248
+	DamageDelay: 393
 	DamageMotion: 576
 	Drops: {
 		Chocolate: 10000
@@ -55761,6 +56787,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 76
 	AttackMotion: 864
+	DamageDelay: 810
 	DamageMotion: 288
 	Drops: {
 		Armlet_Of_Prisoner: 4000
@@ -55810,6 +56837,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 1152
 	AttackMotion: 864
+	DamageDelay: 810
 	DamageMotion: 288
 	Drops: {
 		Armlet_Of_Prisoner: 4000
@@ -55859,6 +56887,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 1152
 	AttackMotion: 864
+	DamageDelay: 810
 	DamageMotion: 288
 	Drops: {
 		Armlet_Of_Prisoner: 4000
@@ -55909,6 +56938,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 76
 	AttackMotion: 768
+	DamageDelay: 720
 	DamageMotion: 288
 	Drops: {
 		Goast_Chill: 2
@@ -55959,6 +56989,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 76
 	AttackMotion: 864
+	DamageDelay: 810
 	DamageMotion: 288
 	Drops: {
 		Goast_Chill: 2
@@ -56008,6 +57039,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 76
 	AttackMotion: 864
+	DamageDelay: 810
 	DamageMotion: 288
 	Drops: {
 		Goast_Chill: 2
@@ -56057,6 +57089,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 76
 	AttackMotion: 864
+	DamageDelay: 810
 	DamageMotion: 288
 	Drops: {
 		Goast_Chill: 2
@@ -56111,6 +57144,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 864
+	DamageDelay: 810
 	DamageMotion: 288
 },
 {
@@ -56155,6 +57189,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1152
 	AttackMotion: 864
+	DamageDelay: 810
 	DamageMotion: 288
 },
 {
@@ -56199,6 +57234,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1152
 	AttackMotion: 864
+	DamageDelay: 810
 	DamageMotion: 288
 },
 {
@@ -56243,6 +57279,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 768
+	DamageDelay: 720
 	DamageMotion: 288
 },
 {
@@ -56287,6 +57324,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 864
+	DamageDelay: 810
 	DamageMotion: 288
 },
 {
@@ -56331,6 +57369,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 76
 	AttackMotion: 864
+	DamageDelay: 810
 	DamageMotion: 288
 },
 {
@@ -56375,6 +57414,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 76
 	AttackMotion: 864
+	DamageDelay: 810
 	DamageMotion: 288
 },
 {
@@ -56419,6 +57459,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 864
+	DamageDelay: 810
 	DamageMotion: 288
 	MvpDrops: {
 		Magic_Card_Album: 5000
@@ -56477,6 +57518,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1152
 	AttackMotion: 864
+	DamageDelay: 810
 	DamageMotion: 288
 	MvpDrops: {
 		Magic_Card_Album: 5000
@@ -56536,6 +57578,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1152
 	AttackMotion: 864
+	DamageDelay: 810
 	DamageMotion: 288
 	MvpDrops: {
 		Magic_Card_Album: 5000
@@ -56593,6 +57636,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 768
+	DamageDelay: 720
 	DamageMotion: 288
 	MvpDrops: {
 		Magic_Card_Album: 5000
@@ -56651,6 +57695,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 864
+	DamageDelay: 810
 	DamageMotion: 288
 	MvpDrops: {
 		Magic_Card_Album: 5000
@@ -56709,6 +57754,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 76
 	AttackMotion: 864
+	DamageDelay: 810
 	DamageMotion: 288
 	MvpDrops: {
 		Magic_Card_Album: 5000
@@ -56766,6 +57812,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 76
 	AttackMotion: 864
+	DamageDelay: 810
 	DamageMotion: 288
 	MvpDrops: {
 		Magic_Card_Album: 5000
@@ -56816,6 +57863,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 200
 	AttackMotion: 420
+	DamageDelay: 168
 	DamageMotion: 288
 },
 {
@@ -56852,6 +57900,7 @@ mob_db: (
 	MoveSpeed: 130
 	AttackDelay: 200
 	AttackMotion: 900
+	DamageDelay: 236
 	DamageMotion: 240
 },
 {
@@ -56953,6 +58002,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 912
 	AttackMotion: 1344
+	DamageDelay: 393
 	DamageMotion: 480
 },
 {
@@ -56985,6 +58035,7 @@ mob_db: (
 	MoveSpeed: 445
 	AttackDelay: 106
 	AttackMotion: 1056
+	DamageDelay: 585
 	DamageMotion: 576
 },
 {
@@ -57020,6 +58071,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 2520
 	DamageMotion: 480
 	Drops: {
 		Blue_Card_C: 4000
@@ -57075,6 +58127,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 576
 	AttackMotion: 1380
+	DamageDelay: 303
 	DamageMotion: 360
 	DamageTakenRate: 10
 	MvpExp: 750061
@@ -57134,6 +58187,7 @@ mob_db: (
 	MoveSpeed: 130
 	AttackDelay: 1600
 	AttackMotion: 432
+	DamageDelay: 337
 	DamageMotion: 360
 	Drops: {
 		High_Weapon_Box: 10
@@ -57186,6 +58240,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1344
 	AttackMotion: 2592
+	DamageDelay: 405
 	DamageMotion: 432
 	DamageTakenRate: 10
 	MvpExp: 751725
@@ -57244,6 +58299,7 @@ mob_db: (
 	MoveSpeed: 120
 	AttackDelay: 880
 	AttackMotion: 1224
+	DamageDelay: 472
 	DamageMotion: 360
 	Drops: {
 		High_Weapon_Box: 10
@@ -57297,6 +58353,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 900
 	AttackMotion: 792
+	DamageDelay: 472
 	DamageMotion: 432
 	DamageTakenRate: 10
 	MvpExp: 750780
@@ -57356,6 +58413,7 @@ mob_db: (
 	MoveSpeed: 120
 	AttackDelay: 1000
 	AttackMotion: 1008
+	DamageDelay: 405
 	DamageMotion: 432
 	Drops: {
 		High_Weapon_Box: 10
@@ -57409,6 +58467,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 900
 	AttackMotion: 648
+	DamageDelay: 337
 	DamageMotion: 480
 	DamageTakenRate: 10
 	MvpExp: 802000
@@ -57467,6 +58526,7 @@ mob_db: (
 	MoveSpeed: 120
 	AttackDelay: 1576
 	AttackMotion: 504
+	DamageDelay: 337
 	DamageMotion: 360
 	Drops: {
 		High_Weapon_Box: 10
@@ -57512,6 +58572,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 },
 {
@@ -57548,6 +58609,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 },
 {
@@ -57584,6 +58646,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 },
 {
@@ -57620,6 +58683,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 },
 {
@@ -57656,6 +58720,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 337
 	DamageMotion: 480
 },
 {
@@ -57692,6 +58757,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 337
 	DamageMotion: 480
 },
 {
@@ -57728,6 +58794,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 },
 {
@@ -57765,6 +58832,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 225
 	DamageMotion: 480
 },
 {
@@ -57802,6 +58870,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 225
 	DamageMotion: 480
 },
 {
@@ -57839,6 +58908,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 315
 	DamageMotion: 480
 },
 {
@@ -57876,6 +58946,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 315
 	DamageMotion: 480
 },
 {
@@ -57913,6 +58984,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 315
 	DamageMotion: 480
 },
 {
@@ -57950,6 +59022,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 315
 	DamageMotion: 480
 },
 {
@@ -57987,6 +59060,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 315
 	DamageMotion: 480
 },
 {
@@ -58024,6 +59098,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 315
 	DamageMotion: 480
 },
 {
@@ -58061,6 +59136,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 },
 {
@@ -58098,6 +59174,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 },
 {
@@ -58135,6 +59212,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 },
 {
@@ -58172,6 +59250,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 },
 {
@@ -58208,6 +59287,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 180
 	DamageMotion: 480
 },
 {
@@ -58251,6 +59331,7 @@ mob_db: (
 	MoveSpeed: 130
 	AttackDelay: 1600
 	AttackMotion: 432
+	DamageDelay: 337
 	DamageMotion: 360
 },
 {
@@ -58293,6 +59374,7 @@ mob_db: (
 	MoveSpeed: 120
 	AttackDelay: 880
 	AttackMotion: 1224
+	DamageDelay: 472
 	DamageMotion: 360
 },
 {
@@ -58335,6 +59417,7 @@ mob_db: (
 	MoveSpeed: 120
 	AttackDelay: 1000
 	AttackMotion: 1008
+	DamageDelay: 405
 	DamageMotion: 432
 },
 {
@@ -58377,6 +59460,7 @@ mob_db: (
 	MoveSpeed: 120
 	AttackDelay: 1576
 	AttackMotion: 504
+	DamageDelay: 337
 	DamageMotion: 360
 },
 {
@@ -58820,6 +59904,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 180
 	DamageMotion: 480
 },
 {
@@ -58856,6 +59941,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 720
 	DamageMotion: 480
 },
 {
@@ -58892,6 +59978,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 742
 	DamageMotion: 480
 },
 {
@@ -58928,6 +60015,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 315
 	DamageMotion: 480
 },
 {
@@ -58964,6 +60052,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 225
 	DamageMotion: 480
 },
 {
@@ -59000,6 +60089,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 540
 	DamageMotion: 480
 },
 {
@@ -59036,6 +60126,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 202
 	DamageMotion: 480
 },
 {
@@ -59072,6 +60163,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 225
 	DamageMotion: 480
 },
 {
@@ -59108,6 +60200,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 742
 	DamageMotion: 480
 },
 {
@@ -59144,6 +60237,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 337
 	DamageMotion: 480
 },
 {
@@ -59180,6 +60274,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 675
 	DamageMotion: 480
 },
 {
@@ -59216,6 +60311,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 },
 {
@@ -59252,6 +60348,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 },
 {
@@ -59288,6 +60385,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 },
 {
@@ -59324,6 +60422,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 585
 	DamageMotion: 480
 },
 {
@@ -59360,6 +60459,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 281
 	DamageMotion: 480
 },
 {
@@ -59396,6 +60496,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 225
 	DamageMotion: 480
 },
 {
@@ -59432,6 +60533,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 768
 	AttackMotion: 768
+	DamageDelay: 720
 	DamageMotion: 480
 },
 {
@@ -59468,6 +60570,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 607
 	DamageMotion: 480
 },
 {
@@ -59542,6 +60645,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1568
 	AttackMotion: 432
+	DamageDelay: 405
 	DamageMotion: 360
 	Drops: {
 		Brigan: 2000
@@ -59591,6 +60695,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1424
 	AttackMotion: 576
+	DamageDelay: 540
 	DamageMotion: 360
 	Drops: {
 		Brigan: 2000
@@ -59640,6 +60745,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 280
 	AttackMotion: 720
+	DamageDelay: 675
 	DamageMotion: 360
 	Drops: {
 		Silver_Bracelet: 4000
@@ -59692,6 +60798,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1664
 	AttackMotion: 336
+	DamageDelay: 315
 	DamageMotion: 480
 	Drops: {
 		Brigan: 2000
@@ -59743,6 +60850,7 @@ mob_db: (
 	MoveSpeed: 130
 	AttackDelay: 1064
 	AttackMotion: 936
+	DamageDelay: 877
 	DamageMotion: 360
 	Drops: {
 		Tikbalang_Thick_Spine: 1000
@@ -59791,6 +60899,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 496
 	AttackMotion: 504
+	DamageDelay: 472
 	DamageMotion: 360
 	Drops: {
 		Silver_Bracelet: 3000
@@ -59839,6 +60948,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 424
 	AttackMotion: 576
+	DamageDelay: 540
 	DamageMotion: 360
 	Drops: {
 		Silver_Bracelet: 3000
@@ -59880,6 +60990,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1328
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Jejellopy: 4000
@@ -60013,6 +61124,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1424
 	AttackMotion: 576
+	DamageDelay: 540
 	DamageMotion: 360
 	MvpExp: 1500006
 	Drops: {
@@ -60273,6 +61385,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 868
 	AttackMotion: 480
+	DamageDelay: 540
 	DamageMotion: 120
 },
 {
@@ -60316,6 +61429,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1430
 	AttackMotion: 1080
+	DamageDelay: 450
 	DamageMotion: 1080
 },
 {
@@ -60628,6 +61742,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 424
 	AttackMotion: 576
+	DamageDelay: 540
 	DamageMotion: 360
 },
 {
@@ -60790,6 +61905,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 280
 	AttackMotion: 720
+	DamageDelay: 675
 	DamageMotion: 360
 },
 {
@@ -60833,6 +61949,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1664
 	AttackMotion: 336
+	DamageDelay: 315
 	DamageMotion: 480
 },
 {
@@ -60875,6 +61992,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 496
 	AttackMotion: 504
+	DamageDelay: 472
 	DamageMotion: 360
 },
 {
@@ -61387,6 +62505,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 2070
 	DamageMotion: 480
 },
 {
@@ -61430,6 +62549,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1360
 	AttackMotion: 960
+	DamageDelay: 900
 	DamageMotion: 432
 	Drops: {
 		Nose_Ring: 10000
@@ -61483,6 +62603,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1772
 	AttackMotion: 72
+	DamageDelay: 675
 	DamageMotion: 384
 	Drops: {
 		Rotten_Bandage: 18000
@@ -61536,6 +62657,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 2468
 	AttackMotion: 768
+	DamageDelay: 720
 	DamageMotion: 480
 	Drops: {
 		Immortal_Heart: 18000
@@ -61589,6 +62711,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 972
 	AttackMotion: 500
+	DamageDelay: 630
 	DamageMotion: 288
 	Drops: {
 		Old_Violet_Box: 12
@@ -61641,6 +62764,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 972
 	AttackMotion: 500
+	DamageDelay: 630
 	DamageMotion: 288
 },
 {
@@ -61684,6 +62808,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 960
 	AttackMotion: 500
+	DamageDelay: 900
 	DamageMotion: 480
 	Drops: {
 		Round_Shell: 7000
@@ -61737,6 +62862,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 960
 	AttackMotion: 500
+	DamageDelay: 900
 	DamageMotion: 480
 },
 {
@@ -61780,6 +62906,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 1772
 	AttackMotion: 120
+	DamageDelay: 675
 	DamageMotion: 384
 	Drops: {
 		Rotten_Bandage: 9000
@@ -61833,6 +62960,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 1772
 	AttackMotion: 120
+	DamageDelay: 675
 	DamageMotion: 384
 },
 {
@@ -61871,6 +62999,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 854
 	AttackMotion: 2016
+	DamageDelay: 1181
 	DamageMotion: 480
 	DamageTakenRate: 10
 	MvpExp: 813243
@@ -61931,6 +63060,7 @@ mob_db: (
 	MoveSpeed: 145
 	AttackDelay: 472
 	AttackMotion: 1056
+	DamageDelay: 990
 	DamageMotion: 480
 	Drops: {
 		Fancy_Fairy_Wing: 3000
@@ -61980,6 +63110,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1500
 	AttackMotion: 768
+	DamageDelay: 720
 	DamageMotion: 480
 	Drops: {
 		Pile_Of_Acorn: 3000
@@ -62030,6 +63161,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1500
 	AttackMotion: 720
+	DamageDelay: 675
 	DamageMotion: 360
 	Drops: {
 		Dustball: 5000
@@ -62080,6 +63212,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 864
 	AttackMotion: 960
+	DamageDelay: 900
 	DamageMotion: 480
 	Drops: {
 		Leaf_Bookmark: 3000
@@ -62130,6 +63263,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 480
 	AttackMotion: 1728
+	DamageDelay: 1620
 	DamageMotion: 480
 	Drops: {
 		Star_Crumb: 1000
@@ -62180,6 +63314,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 0
 	AttackMotion: 2304
+	DamageDelay: 3240
 	DamageMotion: 480
 	Drops: {
 		Star_Crumb: 1000
@@ -62230,6 +63365,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 0
 	AttackMotion: 4032
+	DamageDelay: 1260
 	DamageMotion: 480
 	Drops: {
 		Star_Crumb: 1000
@@ -62280,6 +63416,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 0
 	AttackMotion: 3456
+	DamageDelay: 2160
 	DamageMotion: 480
 	Drops: {
 		Star_Crumb: 1000
@@ -62329,6 +63466,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 480
 	AttackMotion: 1536
+	DamageDelay: 1440
 	DamageMotion: 480
 	Drops: {
 		Eye_Drops: 3000
@@ -62374,6 +63512,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 0
 	DamageMotion: 480
 },
 {
@@ -62554,6 +63693,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 225
 	DamageMotion: 480
 },
 {
@@ -62634,6 +63774,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1576
 	AttackMotion: 576
+	DamageDelay: 1710
 	DamageMotion: 420
 	Drops: {
 		Red_Cloth: 6000
@@ -62675,6 +63816,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1576
 	AttackMotion: 576
+	DamageDelay: 720
 	DamageMotion: 420
 	Drops: {
 		Stolen_Cookie: 6000
@@ -62737,6 +63879,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Jellopy: 9000
@@ -62781,6 +63924,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 },
 {
@@ -62876,6 +64020,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 2208
 	AttackMotion: 1008
+	DamageDelay: 540
 	DamageMotion: 324
 	Drops: {
 		Single_Cell: 2000
@@ -62915,6 +64060,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 2228
 	AttackMotion: 528
+	DamageDelay: 315
 	DamageMotion: 576
 	Drops: {
 		Phracon: 45
@@ -62954,6 +64100,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 2276
 	AttackMotion: 576
+	DamageDelay: 202
 	DamageMotion: 432
 	Drops: {
 		Skel_Bone: 1300
@@ -62994,6 +64141,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 2228
 	AttackMotion: 528
+	DamageDelay: 337
 	DamageMotion: 576
 	Drops: {
 		Skel_Bone: 700
@@ -63264,6 +64412,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 432
 	AttackMotion: 400
+	DamageDelay: 720
 	DamageMotion: 288
 },
 //2432,G_L_KATRINN
@@ -63339,6 +64488,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 2612
 	AttackMotion: 912
+	DamageDelay: 855
 	DamageMotion: 288
 	Drops: {
 		Glast_Decayed_Nail: 1000
@@ -63389,6 +64539,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1816
 	AttackMotion: 576
+	DamageDelay: 360
 	DamageMotion: 240
 	Drops: {
 		Crystal_Jewel_: 100
@@ -63439,6 +64590,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 2456
 	AttackMotion: 912
+	DamageDelay: 427
 	DamageMotion: 504
 	Drops: {
 		Oridecon_Stone: 100
@@ -63489,6 +64641,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 960
 	AttackMotion: 500
+	DamageDelay: 450
 	DamageMotion: 480
 	Drops: {
 		Great_Nature: 100
@@ -63537,6 +64690,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 824
 	AttackMotion: 780
+	DamageDelay: 360
 	DamageMotion: 420
 	Drops: {
 		Brigan: 3000
@@ -63586,6 +64740,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1152
 	AttackMotion: 1152
+	DamageDelay: 911
 	DamageMotion: 480
 	Drops: {
 		Brigan: 3000
@@ -63638,6 +64793,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1500
 	AttackMotion: 500
+	DamageDelay: 675
 	DamageMotion: 1000
 	Drops: {
 		Reins: 5000
@@ -63690,6 +64846,7 @@ mob_db: (
 	MoveSpeed: 350
 	AttackDelay: 528
 	AttackMotion: 1000
+	DamageDelay: 225
 	DamageMotion: 396
 	Drops: {
 		Elunium: 50
@@ -63742,6 +64899,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 828
 	AttackMotion: 528
+	DamageDelay: 270
 	DamageMotion: 192
 	Drops: {
 		Two_Hand_Sword: 100
@@ -63794,6 +64952,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 140
 	AttackMotion: 384
+	DamageDelay: 281
 	DamageMotion: 288
 	Drops: {
 		Claymore: 100
@@ -63847,6 +65006,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 140
 	AttackMotion: 384
+	DamageDelay: 281
 	DamageMotion: 288
 	Drops: {
 		Holy_Avenger: 50
@@ -63898,6 +65058,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 854
 	AttackMotion: 2016
+	DamageDelay: 270
 	DamageMotion: 480
 	MvpExp: 449977
 	Drops: {
@@ -63952,6 +65113,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1152
 	AttackMotion: 1152
+	DamageDelay: 281
 	DamageMotion: 576
 	MvpExp: 472831
 	Drops: {
@@ -64005,6 +65167,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 672
 	AttackMotion: 500
+	DamageDelay: 630
 	DamageMotion: 192
 	Drops: {
 		Skull: 4850
@@ -64055,6 +65218,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 864
 	AttackMotion: 500
+	DamageDelay: 438
 	DamageMotion: 192
 	Drops: {
 		Worn_Out_Page: 4850
@@ -64103,6 +65267,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 972
 	AttackMotion: 500
+	DamageDelay: 450
 	DamageMotion: 288
 	Drops: {
 		Old_Violet_Box: 10
@@ -64153,6 +65318,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 2276
 	AttackMotion: 576
+	DamageDelay: 157
 	DamageMotion: 336
 	Drops: {
 		Biretta_: 10
@@ -64202,6 +65368,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 1816
 	AttackMotion: 576
+	DamageDelay: 765
 	DamageMotion: 240
 	Drops: {
 		Transparent_Cloth: 4400
@@ -64251,6 +65418,7 @@ mob_db: (
 	MoveSpeed: 350
 	AttackDelay: 528
 	AttackMotion: 1000
+	DamageDelay: 225
 	DamageMotion: 396
 },
 {
@@ -64294,6 +65462,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 768
 	AttackMotion: 768
+	DamageDelay: 540
 	DamageMotion: 576
 	MvpExp: 198262
 },
@@ -64336,6 +65505,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 868
 	AttackMotion: 480
+	DamageDelay: 540
 	DamageMotion: 120
 },
 {
@@ -64378,6 +65548,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 772
 	AttackMotion: 672
+	DamageDelay: 360
 	DamageMotion: 360
 },
 //2486,ISIS_ANNIV
@@ -64462,6 +65633,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 768
 	AttackMotion: 540
+	DamageDelay: 281
 	DamageMotion: 480
 	MvpExp: 90909
 	MvpDrops: {
@@ -64517,6 +65689,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 768
 	AttackMotion: 540
+	DamageDelay: 281
 	DamageMotion: 480
 	MvpExp: 90909
 	MvpDrops: {
@@ -64568,6 +65741,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 768
 	AttackMotion: 540
+	DamageDelay: 281
 	DamageMotion: 480
 	MvpExp: 90909
 	MvpDrops: {
@@ -64619,6 +65793,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 768
 	AttackMotion: 540
+	DamageDelay: 281
 	DamageMotion: 480
 	MvpExp: 90909
 	MvpDrops: {
@@ -64680,6 +65855,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 73
 	AttackMotion: 384
+	DamageDelay: 1260
 	DamageMotion: 288
 	Drops: {
 		Str_Dish07: 300
@@ -64729,6 +65905,7 @@ mob_db: (
 	MoveSpeed: 225
 	AttackDelay: 73
 	AttackMotion: 348
+	DamageDelay: 900
 	DamageMotion: 288
 	Drops: {
 		Vit_Dish04: 500
@@ -64778,6 +65955,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 73
 	AttackMotion: 348
+	DamageDelay: 900
 	DamageMotion: 288
 	Drops: {
 		Str_Dish06: 500
@@ -64930,6 +66108,7 @@ mob_db: (
 	MoveSpeed: 200 /* Needs more information */
 	AttackDelay: 676 /* Needs more information */
 	AttackMotion: 648 /* Needs more information */
+	DamageDelay: 810 /* Needs more information */
 	DamageMotion: 432 /* Needs more information */
 	Drops: {
 		/* Needs more information */
@@ -64974,6 +66153,7 @@ mob_db: (
 	MoveSpeed: 200 /* Needs more information */
 	AttackDelay: 676 /* Needs more information */
 	AttackMotion: 648 /* Needs more information */
+	DamageDelay: 630 /* Needs more information */
 	DamageMotion: 432 /* Needs more information */
 	Drops: {
 		/* Needs more information */
@@ -65018,6 +66198,7 @@ mob_db: (
 	MoveSpeed: 200 /* Needs more information */
 	AttackDelay: 676 /* Needs more information */
 	AttackMotion: 648 /* Needs more information */
+	DamageDelay: 630 /* Needs more information */
 	DamageMotion: 432 /* Needs more information */
 	Drops: {
 		/* Needs more information */
@@ -65062,6 +66243,7 @@ mob_db: (
 	MoveSpeed: 200 /* Needs more information */
 	AttackDelay: 676 /* Needs more information */
 	AttackMotion: 648 /* Needs more information */
+	DamageDelay: 630 /* Needs more information */
 	DamageMotion: 432 /* Needs more information */
 	Drops: {
 		/* Needs more information */
@@ -65106,6 +66288,7 @@ mob_db: (
 	MoveSpeed: 200 /* Needs more information */
 	AttackDelay: 676 /* Needs more information */
 	AttackMotion: 648 /* Needs more information */
+	DamageDelay: 810 /* Needs more information */
 	DamageMotion: 432 /* Needs more information */
 	Drops: {
 		/* Needs more information */
@@ -65150,6 +66333,7 @@ mob_db: (
 	MoveSpeed: 200 /* Needs more information */
 	AttackDelay: 676 /* Needs more information */
 	AttackMotion: 648 /* Needs more information */
+	DamageDelay: 630 /* Needs more information */
 	DamageMotion: 432 /* Needs more information */
 	Drops: {
 		/* Needs more information */
@@ -65194,6 +66378,7 @@ mob_db: (
 	MoveSpeed: 200 /* Needs more information */
 	AttackDelay: 676 /* Needs more information */
 	AttackMotion: 648 /* Needs more information */
+	DamageDelay: 630 /* Needs more information */
 	DamageMotion: 432 /* Needs more information */
 	Drops: {
 		/* Needs more information */
@@ -65238,6 +66423,7 @@ mob_db: (
 	MoveSpeed: 200 /* Needs more information */
 	AttackDelay: 676 /* Needs more information */
 	AttackMotion: 648 /* Needs more information */
+	DamageDelay: 720 /* Needs more information */
 	DamageMotion: 432 /* Needs more information */
 	Drops: {
 		/* Needs more information */
@@ -65282,6 +66468,7 @@ mob_db: (
 	MoveSpeed: 200 /* Needs more information */
 	AttackDelay: 676 /* Needs more information */
 	AttackMotion: 648 /* Needs more information */
+	DamageDelay: 810 /* Needs more information */
 	DamageMotion: 432 /* Needs more information */
 	Drops: {
 		/* Needs more information */
@@ -65326,6 +66513,7 @@ mob_db: (
 	MoveSpeed: 200 /* Needs more information */
 	AttackDelay: 676 /* Needs more information */
 	AttackMotion: 648 /* Needs more information */
+	DamageDelay: 720 /* Needs more information */
 	DamageMotion: 432 /* Needs more information */
 	Drops: {
 		/* Needs more information */
@@ -65370,6 +66558,7 @@ mob_db: (
 	MoveSpeed: 200 /* Needs more information */
 	AttackDelay: 676 /* Needs more information */
 	AttackMotion: 648 /* Needs more information */
+	DamageDelay: 720 /* Needs more information */
 	DamageMotion: 432 /* Needs more information */
 	Drops: {
 		/* Needs more information */
@@ -65414,6 +66603,7 @@ mob_db: (
 	MoveSpeed: 200 /* Needs more information */
 	AttackDelay: 676 /* Needs more information */
 	AttackMotion: 648 /* Needs more information */
+	DamageDelay: 630 /* Needs more information */
 	DamageMotion: 432 /* Needs more information */
 	Drops: {
 		/* Needs more information */
@@ -65458,6 +66648,7 @@ mob_db: (
 	MoveSpeed: 200 /* Needs more information */
 	AttackDelay: 676 /* Needs more information */
 	AttackMotion: 648 /* Needs more information */
+	DamageDelay: 630 /* Needs more information */
 	DamageMotion: 432 /* Needs more information */
 	Drops: {
 		/* Needs more information */
@@ -65502,6 +66693,7 @@ mob_db: (
 	MoveSpeed: 200 /* Needs more information */
 	AttackDelay: 676 /* Needs more information */
 	AttackMotion: 648 /* Needs more information */
+	DamageDelay: 720 /* Needs more information */
 	DamageMotion: 432 /* Needs more information */
 	Drops: {
 		/* Needs more information */
@@ -65546,6 +66738,7 @@ mob_db: (
 	MoveSpeed: 200 /* Needs more information */
 	AttackDelay: 676 /* Needs more information */
 	AttackMotion: 648 /* Needs more information */
+	DamageDelay: 630 /* Needs more information */
 	DamageMotion: 432 /* Needs more information */
 	Drops: {
 		/* Needs more information */
@@ -65723,6 +66916,7 @@ mob_db: (
 	MoveSpeed: 200 /* Needs more information */
 	AttackDelay: 676 /* Needs more information */
 	AttackMotion: 648 /* Needs more information */
+	DamageDelay: 630 /* Needs more information */
 	DamageMotion: 432 /* Needs more information */
 	Drops: {
 		/* Needs more information */
@@ -65767,6 +66961,7 @@ mob_db: (
 	MoveSpeed: 200 /* Needs more information */
 	AttackDelay: 676 /* Needs more information */
 	AttackMotion: 648 /* Needs more information */
+	DamageDelay: 810 /* Needs more information */
 	DamageMotion: 432 /* Needs more information */
 	Drops: {
 		/* Needs more information */
@@ -65847,6 +67042,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 676
 	AttackMotion: 648
+	DamageDelay: 405
 	DamageMotion: 432
 	Drops: {
 		Clattering_Skull: 3000
@@ -65896,6 +67092,7 @@ mob_db: (
 	MoveSpeed: 350
 	AttackDelay: 1768
 	AttackMotion: 500
+	DamageDelay: 450
 	DamageMotion: 192
 	Drops: {
 		Worn_Out_Prison_Uniform: 3500
@@ -65947,6 +67144,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 2612
 	AttackMotion: 912
+	DamageDelay: 855
 	DamageMotion: 288
 	Drops: {
 		Tatters_Clothes: 4413
@@ -65996,6 +67194,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 2612
 	AttackMotion: 912
+	DamageDelay: 855
 	DamageMotion: 288
 	Drops: {
 		Decayed_Nail: 9000
@@ -66043,6 +67242,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 580
 	AttackMotion: 288
+	DamageDelay: 225
 	DamageMotion: 360
 	Drops: {
 		Screw: 5000
@@ -66091,6 +67291,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1054
 	AttackMotion: 54
+	DamageDelay: 472
 	DamageMotion: 384
 	Drops: {
 		Yoyo_Tail: 9000
@@ -66139,6 +67340,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1054
 	AttackMotion: 54
+	DamageDelay: 472
 	DamageMotion: 384
 	Drops: {
 		Yoyo_Tail: 9000
@@ -66185,6 +67387,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1048
 	AttackMotion: 48
+	DamageDelay: 270
 	DamageMotion: 192
 	Drops: {
 		Yellow_Live: 60
@@ -66234,6 +67437,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 912
 	AttackMotion: 1344
+	DamageDelay: 393
 	DamageMotion: 480
 	Drops: {
 		Meat: 4500
@@ -66279,6 +67483,7 @@ mob_db: (
 	MoveSpeed: 320
 	AttackDelay: 2304
 	AttackMotion: 840
+	DamageDelay: 337
 	DamageMotion: 360
 	Drops: {
 		Iron_Wrist: 5
@@ -66325,6 +67530,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1054
 	AttackMotion: 504
+	DamageDelay: 202
 	DamageMotion: 432
 	Drops: {
 		Emveretarcon: 20
@@ -66377,6 +67583,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1056
 	AttackMotion: 1056
+	DamageDelay: 675
 	DamageMotion: 336
 	Drops: {
 		Zargon: 4559
@@ -66422,6 +67629,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1672
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 432
 	Drops: {
 		Tree_Root: 9000
@@ -66468,6 +67676,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 964
 	AttackMotion: 864
+	DamageDelay: 787
 	DamageMotion: 288
 	Drops: {
 		Cyfar: 5335
@@ -66520,6 +67729,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 637
 	AttackMotion: 1008
+	DamageDelay: 540
 	DamageMotion: 360
 	Drops: {
 		Limpid_Celestial_Robe: 3977
@@ -66570,6 +67780,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1960
 	AttackMotion: 960
+	DamageDelay: 675
 	DamageMotion: 504
 	Drops: {
 		Sparkling_Dust: 150
@@ -66613,6 +67824,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 2228
 	AttackMotion: 576
+	DamageDelay: 315
 	DamageMotion: 528
 	Drops: {
 		Phracon: 45
@@ -66663,6 +67875,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 672
 	AttackMotion: 500
+	DamageDelay: 630
 	DamageMotion: 192
 	Drops: {
 		Skull: 4850
@@ -66710,6 +67923,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 1356
 	AttackMotion: 1056
+	DamageDelay: 225
 	DamageMotion: 540
 	Drops: {
 		Golden_Hair: 6305
@@ -66757,6 +67971,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 1356
 	AttackMotion: 1056
+	DamageDelay: 225
 	DamageMotion: 540
 	Drops: {
 		Golden_Hair: 6305
@@ -66804,6 +68019,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 1356
 	AttackMotion: 1056
+	DamageDelay: 225
 	DamageMotion: 540
 	Drops: {
 		Golden_Hair: 6305
@@ -66853,6 +68069,7 @@ mob_db: (
 	MoveSpeed: 350
 	AttackDelay: 768
 	AttackMotion: 1440
+	DamageDelay: 495
 	DamageMotion: 672
 	Drops: {
 		Air_Pollutant: 5000
@@ -66902,6 +68119,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 504
 	AttackMotion: 1020
+	DamageDelay: 562
 	DamageMotion: 360
 	Drops: {
 		Screw: 2000
@@ -66951,6 +68169,7 @@ mob_db: (
 	MoveSpeed: 270
 	AttackDelay: 1536
 	AttackMotion: 600
+	DamageDelay: 393
 	DamageMotion: 420
 	Drops: {
 		Old_Magic_Circle: 1000
@@ -66999,6 +68218,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 768
 	AttackMotion: 360
+	DamageDelay: 281
 	DamageMotion: 360
 	Drops: {
 		White_Mask: 2500
@@ -67045,6 +68265,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1632
 	AttackMotion: 432
+	DamageDelay: 393
 	DamageMotion: 540
 	Drops: {
 		Nipper: 10000
@@ -67097,6 +68318,7 @@ mob_db: (
 	MoveSpeed: 350
 	AttackDelay: 420
 	AttackMotion: 576
+	DamageDelay: 225
 	DamageMotion: 420
 	Drops: {
 		Long_Limb: 4500
@@ -67144,6 +68366,7 @@ mob_db: (
 	MoveSpeed: 155
 	AttackDelay: 960
 	AttackMotion: 1440
+	DamageDelay: 281
 	DamageMotion: 960
 	Drops: {
 		Talon: 3000
@@ -67193,6 +68416,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 496
 	AttackMotion: 504
+	DamageDelay: 472
 	DamageMotion: 360
 	Drops: {
 		Silver_Bracelet: 1500
@@ -67237,6 +68461,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 720
 	DamageMotion: 768
 	Drops: {
 		Worm_Peelings: 2500
@@ -67284,6 +68509,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 720
 	DamageMotion: 768
 	Drops: {
 		Worm_Peelings: 2500
@@ -67331,6 +68557,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 720
 	DamageMotion: 768
 	Drops: {
 		Worm_Peelings: 2500
@@ -67375,6 +68602,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 2016
 	AttackMotion: 816
+	DamageDelay: 315
 	DamageMotion: 288
 	Drops: {
 		Emveretarcon: 45
@@ -67424,6 +68652,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 512
 	AttackMotion: 780
+	DamageDelay: 562
 	DamageMotion: 504
 	Drops: {
 		Screw: 3800
@@ -67472,6 +68701,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1000
 	AttackMotion: 768
+	DamageDelay: 450
 	DamageMotion: 360
 	Drops: {
 		Lunakaligo: 20
@@ -67518,6 +68748,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1744
 	AttackMotion: 1044
+	DamageDelay: 236
 	DamageMotion: 684
 	Drops: {
 		Rat_Tail: 9000
@@ -67566,6 +68797,7 @@ mob_db: (
 	MoveSpeed: 140
 	AttackDelay: 512
 	AttackMotion: 1152
+	DamageDelay: 360
 	DamageMotion: 672
 	Drops: {
 		Sword_Accessory: 4850
@@ -67616,6 +68848,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 528
 	AttackMotion: 500
+	DamageDelay: 315
 	DamageMotion: 240
 	Drops: {
 		Mud_Lump: 4850
@@ -67665,6 +68898,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1956
 	AttackMotion: 756
+	DamageDelay: 270
 	DamageMotion: 528
 	Drops: {
 		Tough_Scalelike_Stem: 5335
@@ -67714,6 +68948,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1076
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Wind_Of_Verdure: 90
@@ -67760,6 +68995,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 936
 	AttackMotion: 792
+	DamageDelay: 742
 	DamageMotion: 432
 	Drops: {
 		Jellopy: 1000
@@ -67805,6 +69041,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1264
 	AttackMotion: 864
+	DamageDelay: 810
 	DamageMotion: 288
 	Drops: {
 		Mud_Lump: 2000
@@ -67852,6 +69089,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1688
 	AttackMotion: 1188
+	DamageDelay: 675
 	DamageMotion: 612
 	Drops: {
 		Wind_Of_Verdure: 70
@@ -67897,6 +69135,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 630
 	DamageMotion: 288
 	Drops: {
 		Mushroom_Spore: 9000
@@ -67943,6 +69182,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1452
 	AttackMotion: 483
+	DamageDelay: 1350
 	DamageMotion: 528
 	Drops: {
 		Turtle_Shell: 4413
@@ -67992,6 +69232,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 2276
 	AttackMotion: 576
+	DamageDelay: 202
 	DamageMotion: 432
 	Drops: {
 		Skel_Bone: 5500
@@ -68041,6 +69282,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 2276
 	AttackMotion: 576
+	DamageDelay: 202
 	DamageMotion: 432
 	Drops: {
 		Skel_Bone: 5500
@@ -68093,6 +69335,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 576
 	AttackMotion: 420
+	DamageDelay: 360
 	DamageMotion: 360
 	Drops: {
 		Blue_Feather: 200
@@ -68140,6 +69383,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 2112
 	AttackMotion: 912
+	DamageDelay: 303
 	DamageMotion: 576
 	Drops: {
 		Long_Hair: 9000
@@ -68189,6 +69433,7 @@ mob_db: (
 	MoveSpeed: 220
 	AttackDelay: 936
 	AttackMotion: 1020
+	DamageDelay: 618
 	DamageMotion: 420
 	Drops: {
 		Ice_Heart: 3000
@@ -68234,6 +69479,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1576
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 576
 	Drops: {
 		Scale_Of_Snakes: 9000
@@ -68280,6 +69526,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1576
 	AttackMotion: 576
+	DamageDelay: 540
 	DamageMotion: 420
 	Drops: {
 		Raccoon_Leaf: 5500
@@ -68329,6 +69576,7 @@ mob_db: (
 	MoveSpeed: 195
 	AttackDelay: 1350
 	AttackMotion: 1200
+	DamageDelay: 675
 	DamageMotion: 432
 	Drops: {
 		Sand_Lump: 4947
@@ -68378,6 +69626,7 @@ mob_db: (
 	MoveSpeed: 195
 	AttackDelay: 1350
 	AttackMotion: 1200
+	DamageDelay: 675
 	DamageMotion: 432
 	Drops: {
 		Sand_Lump: 4947
@@ -68429,6 +69678,7 @@ mob_db: (
 	MoveSpeed: 190
 	AttackDelay: 720
 	AttackMotion: 384
+	DamageDelay: 337
 	DamageMotion: 480
 	Drops: {
 		Rune_Of_Darkness: 3500
@@ -68480,6 +69730,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 2276
 	AttackMotion: 576
+	DamageDelay: 202
 	DamageMotion: 432
 	Drops: {
 		Burn_Tree: 2550
@@ -68531,6 +69782,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 2276
 	AttackMotion: 576
+	DamageDelay: 202
 	DamageMotion: 432
 	Drops: {
 		Burn_Tree: 2550
@@ -68580,6 +69832,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 2420
 	AttackMotion: 720
+	DamageDelay: 405
 	DamageMotion: 384
 	Drops: {
 		Iron: 400
@@ -68626,6 +69879,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 432
 	AttackMotion: 648
+	DamageDelay: 405
 	DamageMotion: 240
 	Drops: {
 		Ice_Heart: 1000
@@ -68672,6 +69926,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1576
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 576
 	Drops: {
 		Shining_Scales: 5335
@@ -68721,6 +69976,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1576
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 576
 	Drops: {
 		Shining_Scales: 5335
@@ -68772,6 +70028,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1003
 	AttackMotion: 1152
+	DamageDelay: 2160
 	DamageMotion: 336
 	Drops: {
 		Broken_Shuriken: 5335
@@ -68824,6 +70081,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 432
 	AttackMotion: 420
+	DamageDelay: 225
 	DamageMotion: 360
 	Drops: {
 		Red_Feather: 200
@@ -68869,6 +70127,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 864
 	AttackMotion: 864
+	DamageDelay: 438
 	DamageMotion: 384
 	Drops: {
 		Clam_Shell: 5500
@@ -68917,6 +70176,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Armlet_Of_Prisoner: 1500
@@ -68966,6 +70226,7 @@ mob_db: (
 	MoveSpeed: 190
 	AttackDelay: 1132
 	AttackMotion: 583
+	DamageDelay: 405
 	DamageMotion: 532
 	Drops: {
 		Scarlet_Jewel: 150
@@ -69018,6 +70279,7 @@ mob_db: (
 	MoveSpeed: 120
 	AttackDelay: 504
 	AttackMotion: 960
+	DamageDelay: 270
 	DamageMotion: 576
 	Drops: {
 		Tentacle: 2500
@@ -69067,6 +70329,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1564
 	AttackMotion: 864
+	DamageDelay: 360
 	DamageMotion: 576
 	Drops: {
 		Boody_Red: 70
@@ -69112,6 +70375,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1624
 	AttackMotion: 624
+	DamageDelay: 292
 	DamageMotion: 576
 	Drops: {
 		Animals_Skin: 9000
@@ -69158,6 +70422,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1960
 	AttackMotion: 960
+	DamageDelay: 180
 	DamageMotion: 384
 	Drops: {
 		Wild_Boars_Mane: 9000
@@ -69204,6 +70469,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1960
 	AttackMotion: 960
+	DamageDelay: 180
 	DamageMotion: 384
 	Drops: {
 		Wild_Boars_Mane: 9000
@@ -69253,6 +70519,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1672
 	AttackMotion: 720
+	DamageDelay: 630
 	DamageMotion: 288
 	Drops: {
 		Great_Nature: 35
@@ -69306,6 +70573,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 140
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Burning_Heart: 3000
@@ -69355,6 +70623,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 2228
 	AttackMotion: 576
+	DamageDelay: 337
 	DamageMotion: 528
 	Drops: {
 		Skel_Bone: 700
@@ -69402,6 +70671,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1500
 	AttackMotion: 500
+	DamageDelay: 562
 	DamageMotion: 1000
 	Drops: {
 		Rotten_Meat: 3000
@@ -69444,6 +70714,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 2016
 	AttackMotion: 816
+	DamageDelay: 315
 	DamageMotion: 288
 	Drops: {
 		Sticky_Webfoot: 9000
@@ -69487,6 +70758,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 2016
 	AttackMotion: 816
+	DamageDelay: 315
 	DamageMotion: 288
 	Drops: {
 		Sticky_Webfoot: 9000
@@ -69531,6 +70803,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1864
 	AttackMotion: 864
+	DamageDelay: 810
 	DamageMotion: 540
 	Drops: {
 		Grasshoppers_Leg: 9000
@@ -69582,6 +70855,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 864
 	AttackMotion: 500
+	DamageDelay: 438
 	DamageMotion: 192
 	Drops: {
 		Worn_Out_Page: 4850
@@ -69633,6 +70907,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 864
 	AttackMotion: 500
+	DamageDelay: 438
 	DamageMotion: 192
 	Drops: {
 		Worn_Out_Page: 4850
@@ -69679,6 +70954,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 1247
 	AttackMotion: 768
+	DamageDelay: 315
 	DamageMotion: 420
 	Drops: {
 		Bamboo_Cut: 3200
@@ -69730,6 +71006,7 @@ mob_db: (
 	MoveSpeed: 120
 	AttackDelay: 360
 	AttackMotion: 480
+	DamageDelay: 225
 	DamageMotion: 360
 	Drops: {
 		Red_Feather: 400
@@ -69782,6 +71059,7 @@ mob_db: (
 	MoveSpeed: 120
 	AttackDelay: 360
 	AttackMotion: 480
+	DamageDelay: 225
 	DamageMotion: 360
 	Drops: {
 		Red_Feather: 400
@@ -69834,6 +71112,7 @@ mob_db: (
 	MoveSpeed: 120
 	AttackDelay: 360
 	AttackMotion: 480
+	DamageDelay: 225
 	DamageMotion: 360
 	Drops: {
 		Red_Feather: 400
@@ -69883,6 +71162,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1516
 	AttackMotion: 816
+	DamageDelay: 405
 	DamageMotion: 432
 	Drops: {
 		Old_Blue_Box: 35
@@ -69932,6 +71212,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1536
 	AttackMotion: 1056
+	DamageDelay: 315
 	DamageMotion: 1152
 	Drops: {
 		Empty_Bottle: 5000
@@ -69979,6 +71260,7 @@ mob_db: (
 	MoveSpeed: 140
 	AttackDelay: 768
 	AttackMotion: 1224
+	DamageDelay: 393
 	DamageMotion: 432
 	Drops: {
 		Clam_Shell: 2500
@@ -70028,6 +71310,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 824
 	AttackMotion: 780
+	DamageDelay: 360
 	DamageMotion: 420
 	Drops: {
 		Elunium: 106
@@ -70077,6 +71360,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 824
 	AttackMotion: 780
+	DamageDelay: 360
 	DamageMotion: 420
 	Drops: {
 		Elunium: 106
@@ -70126,6 +71410,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 576
 	AttackMotion: 432
+	DamageDelay: 315
 	DamageMotion: 288
 	Drops: {
 		Goast_Chill: 1000
@@ -70176,6 +71461,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 588
 	AttackMotion: 768
+	DamageDelay: 393
 	DamageMotion: 480
 	Drops: {
 		Rakehorn_Helm: 6500
@@ -70225,6 +71511,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1000
 	AttackMotion: 900
+	DamageDelay: 236
 	DamageMotion: 384
 	Drops: {
 		Cyfar: 3000
@@ -70274,6 +71561,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 512
 	AttackMotion: 528
+	DamageDelay: 405
 	DamageMotion: 240
 	Drops: {
 		Root_Of_Maneater: 5500
@@ -70320,6 +71608,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Jellopy: 7000
@@ -70366,6 +71655,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Jellopy: 7000
@@ -70412,6 +71702,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Jellopy: 7000
@@ -70458,6 +71749,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Jellopy: 7000
@@ -70505,6 +71797,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 720
 	AttackMotion: 360
+	DamageDelay: 112
 	DamageMotion: 360
 	Drops: {
 		Jubilee: 5000
@@ -70550,6 +71843,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1672
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Sticky_Mucus: 5500
@@ -70596,6 +71890,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1672
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Sticky_Mucus: 5500
@@ -70642,6 +71937,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1672
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Sticky_Mucus: 5500
@@ -70687,6 +71983,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 1148
 	AttackMotion: 1728
+	DamageDelay: 585
 	DamageMotion: 864
 	Drops: {
 		Poison_Toads_Skin: 5500
@@ -70736,6 +72033,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1672
 	AttackMotion: 672
+	DamageDelay: 630
 	DamageMotion: 288
 	Drops: {
 		Poison_Spore: 9000
@@ -70785,6 +72083,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1056
 	AttackMotion: 1056
+	DamageDelay: 1215
 	DamageMotion: 336
 	Drops: {
 		Scell: 100
@@ -70829,6 +72128,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 2208
 	AttackMotion: 1008
+	DamageDelay: 540
 	DamageMotion: 324
 	Drops: {
 		Single_Cell: 9000
@@ -70875,6 +72175,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 960
 	AttackMotion: 336
+	DamageDelay: 225
 	DamageMotion: 300
 	Drops: {
 		Old_Pick: 3000
@@ -70924,6 +72225,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 768
 	AttackMotion: 480
+	DamageDelay: 270
 	DamageMotion: 864
 	Drops: {
 		Gill: 600
@@ -70972,6 +72274,7 @@ mob_db: (
 	MoveSpeed: 290
 	AttackDelay: 1426
 	AttackMotion: 600
+	DamageDelay: 337
 	DamageMotion: 360
 	Drops: {
 		Sharp_Leaf: 5000
@@ -71021,6 +72324,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 700
 	AttackMotion: 600
+	DamageDelay: 281
 	DamageMotion: 360
 	Drops: {
 		Pinguicula_Corsage: 1
@@ -71066,6 +72370,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 988
 	AttackMotion: 288
+	DamageDelay: 270
 	DamageMotion: 168
 	Drops: {
 		Feather_Of_Birds: 9000
@@ -71112,6 +72417,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 2544
 	AttackMotion: 1344
+	DamageDelay: 405
 	DamageMotion: 1152
 	Drops: {
 		Fish_Tail: 5500
@@ -71160,6 +72466,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 2468
 	AttackMotion: 768
+	DamageDelay: 315
 	DamageMotion: 480
 	Drops: {
 		Dragon_Canine: 5335
@@ -71209,6 +72516,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 2468
 	AttackMotion: 768
+	DamageDelay: 315
 	DamageMotion: 480
 	Drops: {
 		Dragon_Canine: 5335
@@ -71260,6 +72568,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 832
 	AttackMotion: 500
+	DamageDelay: 315
 	DamageMotion: 600
 	Drops: {
 		Coral_Reef: 4850
@@ -71311,6 +72620,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 832
 	AttackMotion: 500
+	DamageDelay: 315
 	DamageMotion: 600
 	Drops: {
 		Coral_Reef: 4850
@@ -71358,6 +72668,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1564
 	AttackMotion: 864
+	DamageDelay: 450
 	DamageMotion: 576
 	Drops: {
 		Bill_Of_Birds: 9000
@@ -71406,6 +72717,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 976
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 288
 	Drops: {
 		Vroken_Sword: 4365
@@ -71450,6 +72762,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 864
 	AttackMotion: 864
+	DamageDelay: 270
 	DamageMotion: 672
 	Drops: {
 		Germinating_Sprout: 5500
@@ -71503,6 +72816,7 @@ mob_db: (
 	MoveSpeed: 195
 	AttackDelay: 1345
 	AttackMotion: 824
+	DamageDelay: 720
 	DamageMotion: 440
 	Drops: {
 		Tatters_Clothes: 4413
@@ -71552,6 +72866,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1864
 	AttackMotion: 864
+	DamageDelay: 810
 	DamageMotion: 288
 	Drops: {
 		Wing_Of_Fly: 210
@@ -71601,6 +72916,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 2852
 	AttackMotion: 1152
+	DamageDelay: 720
 	DamageMotion: 840
 	Drops: {
 		Nail_Of_Orc: 5500
@@ -71646,6 +72962,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 2420
 	AttackMotion: 720
+	DamageDelay: 270
 	DamageMotion: 648
 	Drops: {
 		Orcish_Cuspid: 5500
@@ -71696,6 +73013,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1050
 	AttackMotion: 900
+	DamageDelay: 506
 	DamageMotion: 288
 	Drops: {
 		Cyfar: 4656
@@ -71748,6 +73066,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 432
 	AttackMotion: 480
+	DamageDelay: 281
 	DamageMotion: 360
 	Drops: {
 		Blue_Feather: 500
@@ -71797,6 +73116,7 @@ mob_db: (
 	MoveSpeed: 350
 	AttackDelay: 768
 	AttackMotion: 1440
+	DamageDelay: 495
 	DamageMotion: 672
 	Drops: {
 		Poisonous_Gas: 1000
@@ -71846,6 +73166,7 @@ mob_db: (
 	MoveSpeed: 110
 	AttackDelay: 151
 	AttackMotion: 288
+	DamageDelay: 225
 	DamageMotion: 360
 	Drops: {
 		Green_Herb: 3000
@@ -71891,6 +73212,7 @@ mob_db: (
 	MoveSpeed: 110
 	AttackDelay: 151
 	AttackMotion: 288
+	DamageDelay: 225
 	DamageMotion: 360
 	Drops: {
 		Green_Herb: 3000
@@ -71936,6 +73258,7 @@ mob_db: (
 	MoveSpeed: 110
 	AttackDelay: 151
 	AttackMotion: 288
+	DamageDelay: 225
 	DamageMotion: 360
 	Drops: {
 		Green_Herb: 3000
@@ -71981,6 +73304,7 @@ mob_db: (
 	MoveSpeed: 110
 	AttackDelay: 151
 	AttackMotion: 288
+	DamageDelay: 225
 	DamageMotion: 360
 	Drops: {
 		Green_Herb: 3000
@@ -72027,6 +73351,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1216
 	AttackMotion: 816
+	DamageDelay: 765
 	DamageMotion: 432
 	Drops: {
 		Burning_Horse_Shoe: 4947
@@ -72078,6 +73403,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 1816
 	AttackMotion: 576
+	DamageDelay: 765
 	DamageMotion: 240
 },
 {
@@ -72118,6 +73444,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 672
 	AttackMotion: 500
+	DamageDelay: 630
 	DamageMotion: 192
 },
 {
@@ -72153,6 +73480,7 @@ mob_db: (
 	MoveSpeed: 1000
 	AttackDelay: 500
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 504
 	Drops: {
 		Mandragora_Cap: 1
@@ -72206,6 +73534,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1816
 	AttackMotion: 1320
+	DamageDelay: 731
 	DamageMotion: 420
 	Drops: {
 		Clattering_Skull: 3000
@@ -72252,6 +73581,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1248
 	AttackMotion: 1248
+	DamageDelay: 405
 	DamageMotion: 432
 	Drops: {
 		Candy_Striper: 90
@@ -72297,6 +73627,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 672
 	AttackMotion: 648
+	DamageDelay: 472
 	DamageMotion: 360
 	Drops: {
 		Sticky_Poison: 3000
@@ -72346,6 +73677,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1772
 	AttackMotion: 72
+	DamageDelay: 270
 	DamageMotion: 384
 	Drops: {
 		Rotten_Bandage: 9000
@@ -72395,6 +73727,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1772
 	AttackMotion: 72
+	DamageDelay: 270
 	DamageMotion: 384
 	Drops: {
 		Rotten_Bandage: 9000
@@ -72440,6 +73773,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1960
 	AttackMotion: 960
+	DamageDelay: 450
 	DamageMotion: 384
 	Drops: {
 		Yellow_Live: 70
@@ -72493,6 +73827,7 @@ mob_db: (
 	MoveSpeed: 110
 	AttackDelay: 576
 	AttackMotion: 480
+	DamageDelay: 405
 	DamageMotion: 432
 	Drops: {
 		Herald_Of_GOD: 10
@@ -72545,6 +73880,7 @@ mob_db: (
 	MoveSpeed: 110
 	AttackDelay: 576
 	AttackMotion: 480
+	DamageDelay: 405
 	DamageMotion: 432
 	Drops: {
 		Herald_Of_GOD: 10
@@ -72597,6 +73933,7 @@ mob_db: (
 	MoveSpeed: 110
 	AttackDelay: 576
 	AttackMotion: 480
+	DamageDelay: 405
 	DamageMotion: 432
 	Drops: {
 		Herald_Of_GOD: 10
@@ -72643,6 +73980,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1400
 	AttackMotion: 960
+	DamageDelay: 225
 	DamageMotion: 504
 	Drops: {
 		Moustache_Of_Mole: 5000
@@ -72687,6 +74025,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1938
 	AttackMotion: 2112
+	DamageDelay: 1980
 	DamageMotion: 768
 	Drops: {
 		Glossy_Hair: 5335
@@ -72736,6 +74075,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1360
 	AttackMotion: 960
+	DamageDelay: 540
 	DamageMotion: 432
 	Drops: {
 		Nose_Ring: 5335
@@ -72785,6 +74125,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1360
 	AttackMotion: 960
+	DamageDelay: 540
 	DamageMotion: 432
 	Drops: {
 		Nose_Ring: 5335
@@ -72834,6 +74175,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1360
 	AttackMotion: 960
+	DamageDelay: 540
 	DamageMotion: 432
 	Drops: {
 		Nose_Ring: 5335
@@ -72880,6 +74222,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 648
 	AttackMotion: 480
+	DamageDelay: 281
 	DamageMotion: 360
 	Drops: {
 		Fragment_Of_Crystal: 3000
@@ -72929,6 +74272,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 576
 	AttackMotion: 1140
+	DamageDelay: 225
 	DamageMotion: 504
 	Drops: {
 		Golden_Feather: 5000
@@ -72975,6 +74319,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 972
 	AttackMotion: 500
+	DamageDelay: 450
 	DamageMotion: 288
 	Drops: {
 		Old_Violet_Box: 5
@@ -73024,6 +74369,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 972
 	AttackMotion: 500
+	DamageDelay: 450
 	DamageMotion: 288
 	Drops: {
 		Old_Violet_Box: 5
@@ -73073,6 +74419,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1708
 	AttackMotion: 1008
+	DamageDelay: 472
 	DamageMotion: 540
 	Drops: {
 		Boody_Red: 60
@@ -73119,6 +74466,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 384
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Tube: 4000
@@ -73165,6 +74513,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 384
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Tube: 4000
@@ -73216,6 +74565,7 @@ mob_db: (
 	MoveSpeed: 220
 	AttackDelay: 916
 	AttackMotion: 816
+	DamageDelay: 360
 	DamageMotion: 336
 	Drops: {
 		Lip_Of_Ancient_Fish: 1300
@@ -73268,6 +74618,7 @@ mob_db: (
 	MoveSpeed: 145
 	AttackDelay: 472
 	AttackMotion: 1056
+	DamageDelay: 990
 	DamageMotion: 480
 	Drops: {
 		Fancy_Fairy_Wing: 2000
@@ -73316,6 +74667,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 1720
 	AttackMotion: 1320
+	DamageDelay: 1012
 	DamageMotion: 360
 	Drops: {
 		Slender_Snake: 5335
@@ -73361,6 +74713,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1480
 	AttackMotion: 480
+	DamageDelay: 180
 	DamageMotion: 480
 	Drops: {
 		Moustache_Of_Mole: 9000
@@ -73411,6 +74764,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1480
 	AttackMotion: 480
+	DamageDelay: 225
 	DamageMotion: 1056
 	Drops: {
 		Golden_Hair: 9000
@@ -73457,6 +74811,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Garlet: 3200
@@ -73506,6 +74861,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1540
 	AttackMotion: 840
+	DamageDelay: 405
 	DamageMotion: 504
 	Drops: {
 		Flame_Heart: 35
@@ -73556,6 +74912,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1528
 	AttackMotion: 660
+	DamageDelay: 315
 	DamageMotion: 432
 	Drops: {
 		Yellow_Live: 110
@@ -73601,6 +74958,7 @@ mob_db: (
 	MoveSpeed: 1000
 	AttackDelay: 1768
 	AttackMotion: 768
+	DamageDelay: 360
 	DamageMotion: 576
 	Drops: {
 		Yellow_Live: 50
@@ -73653,6 +75011,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 280
 	AttackMotion: 720
+	DamageDelay: 675
 	DamageMotion: 360
 	Drops: {
 		Silver_Bracelet: 2000
@@ -73704,6 +75063,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1100
 	AttackMotion: 960
+	DamageDelay: 1800
 	DamageMotion: 780
 	Drops: {
 		Nose_Ring: 4413
@@ -73751,6 +75111,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1054
 	AttackMotion: 504
+	DamageDelay: 180
 	DamageMotion: 432
 	Drops: {
 		Old_Frying_Pan: 9000
@@ -73797,6 +75158,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1472
 	AttackMotion: 384
+	DamageDelay: 315
 	DamageMotion: 288
 	Drops: {
 		Burning_Heart: 3000
@@ -73837,6 +75199,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1456
 	AttackMotion: 456
+	DamageDelay: 247
 	DamageMotion: 336
 	Drops: {
 		Clover: 6500
@@ -73882,6 +75245,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1456
 	AttackMotion: 456
+	DamageDelay: 247
 	DamageMotion: 336
 	Drops: {
 		Clover: 6500
@@ -73931,6 +75295,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 890
 	AttackMotion: 960
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Pumpkin_Bucket: 3200
@@ -73984,6 +75349,7 @@ mob_db: (
 	MoveSpeed: 110
 	AttackDelay: 1000
 	AttackMotion: 864
+	DamageDelay: 675
 	DamageMotion: 432
 	Drops: {
 		Sprint_Ring: 2
@@ -74034,6 +75400,7 @@ mob_db: (
 	MoveSpeed: 125
 	AttackDelay: 747
 	AttackMotion: 1632
+	DamageDelay: 1530
 	DamageMotion: 576
 	Drops: {
 		Black_Kitty_Doll: 800
@@ -74081,6 +75448,7 @@ mob_db: (
 	MoveSpeed: 410
 	AttackDelay: 400
 	AttackMotion: 672
+	DamageDelay: 630
 	DamageMotion: 480
 	Drops: {
 		Hard_Peach: 4365
@@ -74126,6 +75494,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Jellopy: 9000
@@ -74175,6 +75544,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 432
 	AttackMotion: 300
+	DamageDelay: 225
 	DamageMotion: 432
 	Drops: {
 		Angel_Magic_Power: 5000
@@ -74222,6 +75592,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1120
 	AttackMotion: 576
+	DamageDelay: 315
 	DamageMotion: 420
 	Drops: {
 		Tiger_Skin_Panties: 4500
@@ -74266,6 +75637,7 @@ mob_db: (
 	MoveSpeed: 230
 	AttackDelay: 1728
 	AttackMotion: 720
+	DamageDelay: 393
 	DamageMotion: 576
 	Drops: {
 		Sharp_Leaf: 2000
@@ -74316,6 +75688,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 1260
 	AttackMotion: 230
+	DamageDelay: 1260
 	DamageMotion: 192
 	Drops: {
 		Bears_Foot: 4550
@@ -74362,6 +75735,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 960
 	AttackMotion: 864
+	DamageDelay: 810
 	DamageMotion: 720
 	Drops: {
 		Great_Leaf: 4365
@@ -74409,6 +75783,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1008
 	AttackMotion: 1008
+	DamageDelay: 472
 	DamageMotion: 384
 	Drops: {
 		Zargon: 250
@@ -74458,6 +75833,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1028
 	AttackMotion: 528
+	DamageDelay: 225
 	DamageMotion: 360
 	Drops: {
 		Steel: 100
@@ -74504,6 +75880,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1548
 	AttackMotion: 384
+	DamageDelay: 225
 	DamageMotion: 288
 	Drops: {
 		Great_Nature: 30
@@ -74552,6 +75929,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1247
 	AttackMotion: 768
+	DamageDelay: 225
 	DamageMotion: 576
 	Drops: {
 		Solid_Peeling: 6500
@@ -74603,6 +75981,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 800
 	AttackMotion: 600
+	DamageDelay: 506
 	DamageMotion: 288
 	Drops: {
 		Burning_Heart: 3000
@@ -74648,6 +76027,7 @@ mob_db: (
 	MoveSpeed: 155
 	AttackDelay: 1638
 	AttackMotion: 2016
+	DamageDelay: 405
 	DamageMotion: 576
 	Drops: {
 		Oil_Paper: 5000
@@ -74698,6 +76078,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1384
 	AttackMotion: 768
+	DamageDelay: 450
 	DamageMotion: 336
 	Drops: {
 		Scales_Shell: 5335
@@ -74747,6 +76128,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 768
 	AttackMotion: 360
+	DamageDelay: 337
 	DamageMotion: 432
 	Drops: {
 		White_Mask: 2500
@@ -74798,6 +76180,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 770
 	AttackMotion: 720
+	DamageDelay: 506
 	DamageMotion: 336
 	Drops: {
 		Steel: 300
@@ -74844,6 +76227,7 @@ mob_db: (
 	MoveSpeed: 445
 	AttackDelay: 106
 	AttackMotion: 1056
+	DamageDelay: 585
 	DamageMotion: 576
 	Drops: {
 		Dried_Sand: 4365
@@ -74890,6 +76274,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 861
 	AttackMotion: 660
+	DamageDelay: 562
 	DamageMotion: 144
 	Drops: {
 		Ice_Heart: 5000
@@ -74936,6 +76321,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 384
 	AttackMotion: 672
+	DamageDelay: 360
 	DamageMotion: 288
 	Drops: {
 		Mistic_Frozen: 5
@@ -74984,6 +76370,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 890
 	AttackMotion: 1320
+	DamageDelay: 1237
 	DamageMotion: 720
 	Drops: {
 		Brigan: 3880
@@ -75033,6 +76420,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 676
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Rough_Wind: 30
@@ -75080,6 +76468,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1292
 	AttackMotion: 792
+	DamageDelay: 742
 	DamageMotion: 216
 	Drops: {
 		Wind_Of_Verdure: 80
@@ -75127,6 +76516,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 384
 	AttackMotion: 672
+	DamageDelay: 337
 	DamageMotion: 360
 	Drops: {
 		Singlehorn_Helm: 6500
@@ -75172,6 +76562,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1528
 	AttackMotion: 528
+	DamageDelay: 315
 	DamageMotion: 288
 	Drops: {
 		Yellow_Live: 80
@@ -75221,6 +76612,7 @@ mob_db: (
 	MoveSpeed: 140
 	AttackDelay: 960
 	AttackMotion: 528
+	DamageDelay: 360
 	DamageMotion: 432
 	Drops: {
 		Prickly_Fruit_: 1000
@@ -75266,6 +76658,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1480
 	AttackMotion: 480
+	DamageDelay: 270
 	DamageMotion: 720
 	Drops: {
 		Yellow_Live: 120
@@ -75315,6 +76708,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 504
 	AttackMotion: 480
+	DamageDelay: 270
 	DamageMotion: 360
 	Drops: {
 		Harpys_Feather: 4000
@@ -75361,6 +76755,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 504
 	AttackMotion: 480
+	DamageDelay: 270
 	DamageMotion: 360
 	Drops: {
 		Harpys_Feather: 4000
@@ -75409,6 +76804,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1500
 	AttackMotion: 500
+	DamageDelay: 405
 	DamageMotion: 1000
 	Drops: {
 		Ogre_Tooth: 2500
@@ -75459,6 +76855,7 @@ mob_db: (
 	MoveSpeed: 155
 	AttackDelay: 972
 	AttackMotion: 672
+	DamageDelay: 360
 	DamageMotion: 470
 	Drops: {
 		Harpys_Feather: 4850
@@ -75508,6 +76905,7 @@ mob_db: (
 	MoveSpeed: 155
 	AttackDelay: 972
 	AttackMotion: 672
+	DamageDelay: 360
 	DamageMotion: 470
 	Drops: {
 		Harpys_Feather: 4850
@@ -75553,6 +76951,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1152
 	AttackMotion: 1152
+	DamageDelay: 315
 	DamageMotion: 480
 	Drops: {
 		Leaflet_Of_Aloe: 1500
@@ -75598,6 +76997,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1152
 	AttackMotion: 1152
+	DamageDelay: 765
 	DamageMotion: 384
 	Drops: {
 		Brigan: 2000
@@ -75645,6 +77045,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1460
 	AttackMotion: 960
+	DamageDelay: 2340
 	DamageMotion: 432
 	Drops: {
 		Peco_Wing_Feather: 4850
@@ -75690,6 +77091,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1460
 	AttackMotion: 960
+	DamageDelay: 2340
 	DamageMotion: 432
 	Drops: {
 		Peco_Wing_Feather: 4850
@@ -75734,6 +77136,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1608
 	AttackMotion: 816
+	DamageDelay: 945
 	DamageMotion: 396
 	Drops: {
 		Steel: 150
@@ -75785,6 +77188,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1120
 	AttackMotion: 620
+	DamageDelay: 360
 	DamageMotion: 240
 	Drops: {
 		Wing_Of_Fly: 270
@@ -75836,6 +77240,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1120
 	AttackMotion: 620
+	DamageDelay: 360
 	DamageMotion: 240
 	Drops: {
 		Wing_Of_Fly: 270
@@ -75883,6 +77288,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1380
 	AttackMotion: 1080
+	DamageDelay: 675
 	DamageMotion: 336
 	Drops: {
 		Goats_Horn: 4559
@@ -75930,6 +77336,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1380
 	AttackMotion: 1080
+	DamageDelay: 675
 	DamageMotion: 336
 	Drops: {
 		Goats_Horn: 4559
@@ -76184,6 +77591,7 @@ mob_db: (
 	MoveSpeed: 155
 	AttackDelay: 1292
 	AttackMotion: 792
+	DamageDelay: 742
 	DamageMotion: 340
 	Drops: {
 		Royal_Jelly: 550
@@ -76233,6 +77641,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 2456
 	AttackMotion: 912
+	DamageDelay: 427
 	DamageMotion: 504
 	Drops: {
 		Horrendous_Mouth: 6000
@@ -76282,6 +77691,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 2456
 	AttackMotion: 912
+	DamageDelay: 427
 	DamageMotion: 504
 	Drops: {
 		Horrendous_Mouth: 6000
@@ -76327,6 +77737,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 1308
 	AttackMotion: 1008
+	DamageDelay: 450
 	DamageMotion: 480
 	Drops: {
 		Blossom_Of_Maneater: 6200
@@ -76370,6 +77781,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 1308
 	AttackMotion: 1008
+	DamageDelay: 450
 	DamageMotion: 480
 	Drops: {
 		Blossom_Of_Maneater: 6200
@@ -76416,6 +77828,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1020
 	AttackMotion: 720
+	DamageDelay: 562
 	DamageMotion: 384
 	Drops: {
 		Zargon: 3880
@@ -76464,6 +77877,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1020
 	AttackMotion: 720
+	DamageDelay: 562
 	DamageMotion: 384
 	Drops: {
 		Zargon: 3880
@@ -76514,6 +77928,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 864
 	AttackMotion: 624
+	DamageDelay: 450
 	DamageMotion: 360
 	Drops: {
 		Rotten_Meat: 3000
@@ -76560,6 +77975,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1612
 	AttackMotion: 622
+	DamageDelay: 540
 	DamageMotion: 583
 	Drops: {
 		Zargon: 4365
@@ -76611,6 +78027,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 1260
 	AttackMotion: 960
+	DamageDelay: 506
 	DamageMotion: 672
 	Drops: {
 		Turtle_Shell: 4413
@@ -76662,6 +78079,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 1260
 	AttackMotion: 960
+	DamageDelay: 506
 	DamageMotion: 672
 	Drops: {
 		Turtle_Shell: 4413
@@ -76711,6 +78129,7 @@ mob_db: (
 	MoveSpeed: 120
 	AttackDelay: 108
 	AttackMotion: 576
+	DamageDelay: 360
 	DamageMotion: 432
 	Drops: {
 		Delicious_Fish: 5100
@@ -76758,6 +78177,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1276
 	AttackMotion: 576
+	DamageDelay: 540
 	DamageMotion: 384
 	Drops: {
 		Tooth_Of_Bat: 5500
@@ -76807,6 +78227,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 920
 	AttackMotion: 720
+	DamageDelay: 393
 	DamageMotion: 336
 	Drops: {
 		Blue_Gemstone: 1000
@@ -76851,6 +78272,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1672
 	AttackMotion: 672
+	DamageDelay: 180
 	DamageMotion: 480
 	Drops: {
 		Fluff: 6500
@@ -76897,6 +78319,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1672
 	AttackMotion: 672
+	DamageDelay: 180
 	DamageMotion: 480
 	Drops: {
 		Fluff: 6500
@@ -76946,6 +78369,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1260
 	AttackMotion: 960
+	DamageDelay: 450
 	DamageMotion: 336
 	Drops: {
 		Wing_Of_Red_Bat: 5500
@@ -76995,6 +78419,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 2276
 	AttackMotion: 576
+	DamageDelay: 157
 	DamageMotion: 336
 	Drops: {
 		Biretta_: 10
@@ -77044,6 +78469,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1372
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 432
 	Drops: {
 		Resin: 5000
@@ -77093,6 +78519,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1372
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 432
 	Drops: {
 		Resin: 5000
@@ -77143,6 +78570,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 768
 	AttackMotion: 360
+	DamageDelay: 281
 	DamageMotion: 360
 	Drops: {
 		Suspicious_Hat: 2500
@@ -77190,6 +78618,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1004
 	AttackMotion: 504
+	DamageDelay: 236
 	DamageMotion: 384
 	Drops: {
 		Moth_Dust: 9000
@@ -77238,6 +78667,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 950
 	AttackMotion: 2520
+	DamageDelay: 270
 	DamageMotion: 576
 	Drops: {
 		Tough_Vines: 5335
@@ -77283,6 +78713,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 864
 	AttackMotion: 576
+	DamageDelay: 472
 	DamageMotion: 336
 	Drops: {
 		Sticky_Poison: 3000
@@ -77329,6 +78760,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1372
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Jellopy: 7500
@@ -77378,6 +78810,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1300
 	AttackMotion: 900
+	DamageDelay: 506
 	DamageMotion: 336
 	Drops: {
 		Lizard_Scruff: 7500
@@ -77423,6 +78856,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1276
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 384
 	Drops: {
 		Emveretarcon: 60
@@ -77475,6 +78909,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 862
 	AttackMotion: 534
+	DamageDelay: 337
 	DamageMotion: 312
 	Drops: {
 		Dragon_Fly_Wing: 4413
@@ -77522,6 +78957,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 576
 	AttackMotion: 960
+	DamageDelay: 393
 	DamageMotion: 504
 	Drops: {
 		Dragons_Mane: 3000
@@ -77572,6 +79008,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 360
 	AttackMotion: 360
+	DamageDelay: 281
 	DamageMotion: 600
 	Drops: {
 		Small_Bradium: 3000
@@ -77619,6 +79056,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1156
 	AttackMotion: 456
+	DamageDelay: 270
 	DamageMotion: 384
 	Drops: {
 		Dokkaebi_Horn: 9000
@@ -77669,6 +79107,7 @@ mob_db: (
 	MoveSpeed: 147
 	AttackDelay: 516
 	AttackMotion: 768
+	DamageDelay: 337
 	DamageMotion: 384
 	Drops: {
 		Red_Scarf: 4850
@@ -77718,6 +79157,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 576
 	AttackMotion: 720
+	DamageDelay: 315
 	DamageMotion: 432
 	Drops: {
 		Old_Steel_Plate: 2000
@@ -77770,6 +79210,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 980
 	AttackMotion: 600
+	DamageDelay: 270
 	DamageMotion: 384
 	Drops: {
 		Petite_DiablOfs_Horn: 5335
@@ -77816,6 +79257,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1600
 	AttackMotion: 900
+	DamageDelay: 236
 	DamageMotion: 240
 	Drops: {
 		Phracon: 85
@@ -77862,6 +79304,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1600
 	AttackMotion: 900
+	DamageDelay: 236
 	DamageMotion: 240
 	Drops: {
 		Phracon: 85
@@ -77909,6 +79352,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 135
 	DamageMotion: 576
 	Drops: {
 		Worm_Peelings: 9000
@@ -77960,6 +79404,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 176
 	AttackMotion: 912
+	DamageDelay: 495
 	DamageMotion: 300
 	Drops: {
 		Worn_Out_Page: 4000
@@ -78011,6 +79456,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 176
 	AttackMotion: 912
+	DamageDelay: 495
 	DamageMotion: 300
 	Drops: {
 		Worn_Out_Page: 4000
@@ -78062,6 +79508,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 176
 	AttackMotion: 912
+	DamageDelay: 495
 	DamageMotion: 300
 	Drops: {
 		Worn_Out_Page: 4000
@@ -78113,6 +79560,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 864
 	AttackMotion: 1252
+	DamageDelay: 360
 	DamageMotion: 476
 	Drops: {
 		Book_Of_The_Apocalypse: 5
@@ -78159,6 +79607,7 @@ mob_db: (
 	MoveSpeed: 160
 	AttackDelay: 600
 	AttackMotion: 840
+	DamageDelay: 450
 	DamageMotion: 504
 	Drops: {
 		Dragon_Fang: 4365
@@ -78203,6 +79652,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1136
 	AttackMotion: 720
+	DamageDelay: 405
 	DamageMotion: 840
 	Drops: {
 		Powder_Of_Butterfly: 9000
@@ -78249,6 +79699,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1248
 	AttackMotion: 48
+	DamageDelay: 180
 	DamageMotion: 480
 	Drops: {
 		Crystal_Blue: 45
@@ -78296,6 +79747,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1036
 	AttackMotion: 936
+	DamageDelay: 101
 	DamageMotion: 240
 	Drops: {
 		Well_Baked_Cookie: 1000
@@ -78345,6 +79797,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 720
 	AttackMotion: 360
+	DamageDelay: 337
 	DamageMotion: 360
 	Drops: {
 		Burnt_Parts: 100
@@ -78392,6 +79845,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 432
 	AttackMotion: 432
+	DamageDelay: 270
 	DamageMotion: 360
 	Drops: {
 		Comodo_L: 2500
@@ -78435,6 +79889,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1864
 	AttackMotion: 864
+	DamageDelay: 472
 	DamageMotion: 1008
 	Drops: {
 		Acorn: 9000
@@ -78481,6 +79936,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1864
 	AttackMotion: 864
+	DamageDelay: 472
 	DamageMotion: 1008
 	Drops: {
 		Fluff: 3333
@@ -78527,6 +79983,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1092
 	AttackMotion: 792
+	DamageDelay: 405
 	DamageMotion: 480
 	Drops: {
 		Needle_Of_Alarm: 5335
@@ -78573,6 +80030,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1092
 	AttackMotion: 792
+	DamageDelay: 405
 	DamageMotion: 480
 	Drops: {
 		Needle_Of_Alarm: 5335
@@ -78619,6 +80077,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1076
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Jellopy: 10000
@@ -78671,6 +80130,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1000
 	AttackMotion: 792
+	DamageDelay: 540
 	DamageMotion: 336
 	Drops: {
 		Cold_Heart: 2
@@ -78723,6 +80183,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1500
 	AttackMotion: 720
+	DamageDelay: 675
 	DamageMotion: 360
 	Drops: {
 		Dustball: 2000
@@ -78770,6 +80231,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1152
 	AttackMotion: 384
+	DamageDelay: 810
 	DamageMotion: 288
 	Drops: {
 		Armlet_Of_Prisoner: 2000
@@ -78822,6 +80284,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1672
 	AttackMotion: 672
+	DamageDelay: 180
 	DamageMotion: 480
 	Drops: {
 		Feather: 3000
@@ -78874,6 +80337,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1078
 	AttackMotion: 768
+	DamageDelay: 540
 	DamageMotion: 384
 	Drops: {
 		Brigan: 3200
@@ -78918,6 +80382,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1604
 	AttackMotion: 840
+	DamageDelay: 202
 	DamageMotion: 756
 	Drops: {
 		Porcupine_Spike: 9000
@@ -78969,6 +80434,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1568
 	AttackMotion: 432
+	DamageDelay: 405
 	DamageMotion: 360
 	Drops: {
 		Brigan: 1000
@@ -79015,6 +80481,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 140
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 504
 	Drops: {
 		Raccoon_Leaf: 500
@@ -79064,6 +80531,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 140
 	AttackMotion: 384
+	DamageDelay: 270
 	DamageMotion: 504
 	Drops: {
 		Raccoon_Leaf: 500
@@ -79114,6 +80582,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1008
 	AttackMotion: 1200
+	DamageDelay: 450
 	DamageMotion: 540
 	Drops: {
 		Stone_Piece: 3000
@@ -79163,6 +80632,7 @@ mob_db: (
 	MoveSpeed: 145
 	AttackDelay: 472
 	AttackMotion: 576
+	DamageDelay: 450
 	DamageMotion: 288
 	Drops: {
 		Sharp_Feeler: 4608
@@ -79208,6 +80678,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1260
 	AttackMotion: 192
+	DamageDelay: 1181
 	DamageMotion: 192
 	Drops: {
 		Bears_Foot: 9000
@@ -79259,6 +80730,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1504
 	AttackMotion: 840
+	DamageDelay: 270
 	DamageMotion: 900
 	Drops: {
 		Sparkling_Dust: 200
@@ -79311,6 +80783,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 676
 	AttackMotion: 504
+	DamageDelay: 405
 	DamageMotion: 504
 	Drops: {
 		Old_White_Cloth: 3000
@@ -79362,6 +80835,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 676
 	AttackMotion: 504
+	DamageDelay: 405
 	DamageMotion: 504
 	Drops: {
 		Old_White_Cloth: 3000
@@ -79412,6 +80886,7 @@ mob_db: (
 	MoveSpeed: 220
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 1012
 	DamageMotion: 480
 	Drops: {
 		Coal: 500
@@ -79461,6 +80936,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 512
 	AttackMotion: 780
+	DamageDelay: 506
 	DamageMotion: 504
 	Drops: {
 		Turtle_Shell: 4413
@@ -79512,6 +80988,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 512
 	AttackMotion: 780
+	DamageDelay: 202
 	DamageMotion: 504
 	Drops: {
 		Spiderweb: 9000
@@ -79564,6 +81041,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1792
 	AttackMotion: 792
+	DamageDelay: 540
 	DamageMotion: 336
 	Drops: {
 		Short_Leg: 5335
@@ -79615,6 +81093,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1792
 	AttackMotion: 792
+	DamageDelay: 540
 	DamageMotion: 336
 	Drops: {
 		Short_Leg: 5335
@@ -79660,6 +81139,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1840
 	AttackMotion: 1440
+	DamageDelay: 450
 	DamageMotion: 384
 	Drops: {
 		Round_Shell: 3500
@@ -79706,6 +81186,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1840
 	AttackMotion: 1440
+	DamageDelay: 450
 	DamageMotion: 384
 	Drops: {
 		Round_Shell: 3500
@@ -79752,6 +81233,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1840
 	AttackMotion: 1440
+	DamageDelay: 675
 	DamageMotion: 384
 	Drops: {
 		Broken_Steel_Piece: 5335
@@ -79802,6 +81284,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 504
 	AttackMotion: 624
+	DamageDelay: 450
 	DamageMotion: 360
 	Drops: {
 		Antler_Helm: 6500
@@ -79852,6 +81335,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 864
 	AttackMotion: 960
+	DamageDelay: 900
 	DamageMotion: 480
 	Drops: {
 		Leaf_Bookmark: 2000
@@ -79900,6 +81384,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 864
 	AttackMotion: 960
+	DamageDelay: 900
 	DamageMotion: 480
 	Drops: {
 		Leaf_Bookmark: 2000
@@ -79947,6 +81432,7 @@ mob_db: (
 	MoveSpeed: 190
 	AttackDelay: 900
 	AttackMotion: 500
+	DamageDelay: 618
 	DamageMotion: 864
 	Drops: {
 		Anolian_Skin: 4850
@@ -79997,6 +81483,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 576
 	AttackMotion: 480
+	DamageDelay: 315
 	DamageMotion: 480
 	Drops: {
 		Withered_Flower: 5000
@@ -80044,6 +81531,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 576
 	AttackMotion: 480
+	DamageDelay: 315
 	DamageMotion: 480
 	Drops: {
 		Withered_Flower: 5000
@@ -80088,6 +81576,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1288
 	AttackMotion: 288
+	DamageDelay: 168
 	DamageMotion: 384
 	Drops: {
 		Worm_Peelings: 9000
@@ -80137,6 +81626,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 168
 	AttackMotion: 480
+	DamageDelay: 225
 	DamageMotion: 360
 	Drops: {
 		Old_Blue_Box: 30
@@ -80183,6 +81673,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1576
 	AttackMotion: 576
+	DamageDelay: 270
 	DamageMotion: 576
 	Drops: {
 		White_Powder: 200
@@ -80230,6 +81721,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 2048
 	AttackMotion: 648
+	DamageDelay: 292
 	DamageMotion: 648
 	Drops: {
 		Crystal_Blue: 50
@@ -80280,6 +81772,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 768
 	AttackMotion: 768
+	DamageDelay: 337
 	DamageMotion: 576
 	Drops: {
 		Clover: 125
@@ -80325,6 +81818,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1100
 	AttackMotion: 900
+	DamageDelay: 506
 	DamageMotion: 480
 	Drops: {
 		Zargon: 1000
@@ -80369,6 +81863,7 @@ mob_db: (
 	MoveSpeed: 220
 	AttackDelay: 1440
 	AttackMotion: 576
+	DamageDelay: 315
 	DamageMotion: 600
 	Drops: {
 		Brigan: 4000
@@ -80419,6 +81914,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 1080
 	AttackMotion: 480
+	DamageDelay: 225
 	DamageMotion: 504
 	Drops: {
 		Burnt_Parts: 2000
@@ -80470,6 +81966,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1020
 	AttackMotion: 500
+	DamageDelay: 506
 	DamageMotion: 768
 	Drops: {
 		Needle_Of_Alarm: 5335
@@ -80520,6 +82017,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 768
 	AttackMotion: 360
+	DamageDelay: 281
 	DamageMotion: 360
 	Drops: {
 		Suspicious_Hat: 2500
@@ -80569,6 +82067,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 168
 	AttackMotion: 768
+	DamageDelay: 495
 	DamageMotion: 360
 	Drops: {
 		Blue_Potion: 150
@@ -80618,6 +82117,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 168
 	AttackMotion: 768
+	DamageDelay: 495
 	DamageMotion: 360
 	Drops: {
 		Blue_Potion: 150
@@ -80667,6 +82167,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1092
 	AttackMotion: 792
+	DamageDelay: 990
 	DamageMotion: 480
 	Drops: {
 		Needle_Of_Alarm: 3000
@@ -80718,6 +82219,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1020
 	AttackMotion: 500
+	DamageDelay: 630
 	DamageMotion: 768
 	Drops: {
 		Needle_Of_Alarm: 3000
@@ -80763,6 +82265,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1072
 	AttackMotion: 672
+	DamageDelay: 1260
 	DamageMotion: 384
 	Drops: {
 		Needle_Of_Alarm: 3000
@@ -80812,6 +82315,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1500
 	AttackMotion: 500
+	DamageDelay: 1800
 	DamageMotion: 1000
 	Drops: {
 		Mould_Powder: 3000
@@ -80860,6 +82364,7 @@ mob_db: (
 	MoveSpeed: 165
 	AttackDelay: 1552
 	AttackMotion: 1152
+	DamageDelay: 2160
 	DamageMotion: 336
 	Drops: {
 		Old_Magic_Circle: 3000
@@ -80913,6 +82418,7 @@ mob_db: (
 	MoveSpeed: 195
 	AttackDelay: 1345
 	AttackMotion: 824
+	DamageDelay: 2340
 	DamageMotion: 440
 	Drops: {
 		Tatters_Clothes: 2500
@@ -80967,6 +82473,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 1345
 	AttackMotion: 824
+	DamageDelay: 2340
 	DamageMotion: 440
 	Drops: {
 		Tatters_Clothes: 2000
@@ -81016,6 +82523,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1372
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 432
 	Drops: {
 		Moon_Cake20: 500
@@ -81056,6 +82564,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1672
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 432
 	Drops: {
 		Moon_Cake18: 500
@@ -81100,6 +82609,7 @@ mob_db: (
 	MoveSpeed: 155
 	AttackDelay: 972
 	AttackMotion: 672
+	DamageDelay: 360
 	DamageMotion: 470
 	Drops: {
 		Moon_Cake1: 500
@@ -81140,6 +82650,7 @@ mob_db: (
 	MoveSpeed: 250
 	AttackDelay: 648
 	AttackMotion: 480
+	DamageDelay: 281
 	DamageMotion: 360
 	Drops: {
 		Moon_Cake1: 500
@@ -81183,6 +82694,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 917
 	AttackMotion: 1584
+	DamageDelay: 450
 	DamageMotion: 576
 	Drops: {
 		Moon_Cake1: 500
@@ -81226,6 +82738,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 1000
 	AttackMotion: 500
+	DamageDelay: 1215
 	DamageMotion: 1000
 	Drops: {
 		Moon_Cake18: 500
@@ -81270,6 +82783,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 576
 	AttackMotion: 420
+	DamageDelay: 360
 	DamageMotion: 360
 	Drops: {
 		Moon_Cake20: 500
@@ -81309,6 +82823,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 384
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Moon_Cake20: 500
@@ -81348,6 +82863,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1672
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 	Drops: {
 		Moon_Cake20: 500
@@ -81392,6 +82908,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1072
 	AttackMotion: 1056
+	DamageDelay: 990
 	DamageMotion: 384
 	Drops: {
 		Moon_Cake5: 500
@@ -81437,6 +82954,7 @@ mob_db: (
 	MoveSpeed: 180
 	AttackDelay: 1072
 	AttackMotion: 672
+	DamageDelay: 292
 	DamageMotion: 480
 	Drops: {
 		Moon_Cake5: 500
@@ -81478,6 +82996,7 @@ mob_db: (
 	MoveSpeed: 190
 	AttackDelay: 480
 	AttackMotion: 840
+	DamageDelay: 585
 	DamageMotion: 432
 	Drops: {
 		Moon_Cake20: 500
@@ -81512,6 +83031,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1220
 	AttackMotion: 1080
+	DamageDelay: 315
 	DamageMotion: 648
 	Drops: {
 		Pumpkin: 2000
@@ -82051,6 +83571,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 672
 	AttackMotion: 420
+	DamageDelay: 810
 	DamageMotion: 360
 	Drops: {
 		Evil_Horn: 2000
@@ -82098,6 +83619,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 672
 	AttackMotion: 420
+	DamageDelay: 810
 	DamageMotion: 360
 },
 //2962,E_DEVILING
@@ -82209,6 +83731,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 512
 	AttackMotion: 780
+	DamageDelay: 562
 	DamageMotion: 504
 	Drops: {
 		Screw: 1900
@@ -82258,6 +83781,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 768
 	AttackMotion: 1056
+	DamageDelay: 337
 	DamageMotion: 480
 	MvpExp: 444444
 	MvpDrops: {
@@ -82341,6 +83865,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 900
 	AttackMotion: 864
+	DamageDelay: 1080
 	DamageMotion: 480
 	Drops: {
 		Yggdrasilberry: 500
@@ -82435,6 +83960,7 @@ mob_db: (
 	MoveSpeed: 100
 	AttackDelay: 76
 	AttackMotion: 384
+	DamageDelay: 1080
 	DamageMotion: 288
 	DamageTakenRate: 10
 	MvpExp: 2291250
@@ -82677,6 +84203,7 @@ mob_db: (
 	MoveSpeed: 170
 	AttackDelay: 1018
 	AttackMotion: 1008
+	DamageDelay: 990
 	DamageMotion: 300
 	Drops: {
 		Felock_Armor: 100
@@ -82722,6 +84249,7 @@ mob_db: (
 	MoveSpeed: 2000
 	AttackDelay: 500
 	AttackMotion: 500
+	DamageDelay: 1260
 	Drops: {
 		Robe_Of_Sarah: 1000
 		Sarah_Card: 1
@@ -83030,6 +84558,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1672
 	AttackMotion: 672
+	DamageDelay: 1440
 	DamageMotion: 480
 },
 //3295,G_MOBSTER
@@ -83229,6 +84758,7 @@ mob_db: (
 	MoveSpeed: 400
 	AttackDelay: 1872
 	AttackMotion: 672
+	DamageDelay: 67
 	DamageMotion: 480
 	Drops: {
 		Jellopy: 7000
@@ -83270,6 +84800,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1456
 	AttackMotion: 456
+	DamageDelay: 247
 	DamageMotion: 336
 	Drops: {
 		Clover: 7000
@@ -83318,6 +84849,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1384
 	AttackMotion: 768
+	DamageDelay: 450
 	DamageMotion: 336
 },
 {
@@ -83356,6 +84888,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1080
 	AttackMotion: 780
+	DamageDelay: 810
 	DamageMotion: 180
 },
 {
@@ -83392,6 +84925,7 @@ mob_db: (
 	MoveSpeed: 175
 	AttackDelay: 1024
 	AttackMotion: 624
+	DamageDelay: 315
 	DamageMotion: 336
 },
 {
@@ -83423,6 +84957,7 @@ mob_db: (
 	MoveSpeed: 300
 	AttackDelay: 1600
 	AttackMotion: 900
+	DamageDelay: 540
 	DamageMotion: 240
 },
 {
@@ -83455,6 +84990,7 @@ mob_db: (
 	MoveSpeed: 440
 	AttackDelay: 1372
 	AttackMotion: 672
+	DamageDelay: 270
 	DamageMotion: 480
 },
 {
@@ -83490,6 +85026,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 960
 	AttackMotion: 864
+	DamageDelay: 450
 	DamageMotion: 0
 },
 {
@@ -83657,6 +85194,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1276
 	AttackMotion: 576
+	DamageDelay: 112
 	DamageMotion: 288
 },
 {
@@ -83700,6 +85238,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1020
 	AttackMotion: 1020
+	DamageDelay: 303
 	DamageMotion: 288
 },
 {
@@ -83743,6 +85282,7 @@ mob_db: (
 	MoveSpeed: 150
 	AttackDelay: 1678
 	AttackMotion: 780
+	DamageDelay: 731
 	DamageMotion: 648
 },
 {
@@ -83786,6 +85326,7 @@ mob_db: (
 	MoveSpeed: 200
 	AttackDelay: 1344
 	AttackMotion: 2880
+	DamageDelay: 2700
 	DamageMotion: 576
 },
 {/** Needs info. No data found. Using dummy data for now to enable pet. **/

--- a/src/config/core.h
+++ b/src/config/core.h
@@ -106,6 +106,9 @@
 
 /// Uncomment to allow flinch animation and walk delay to be synced
 /// Reduces positional lag when getting hit
+/// Note: Some mobs's act files have improper attack sequences
+/// Consider fixing those before enabling this setting
+/// More info: https://github.com/csnv/act-parser/blob/master/docs/fix-attack-delay.md
 //#define WALKDELAY_SYNC
 
 /**

--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -350,9 +350,16 @@ static int battle_delay_damage(int64 tick, int amotion, struct block_list *src, 
 		BL_UCAST(BL_PC, src)->delayed_damage++;
 	}
 #ifdef WALKDELAY_SYNC
-	timer->add(tick + ddelay, unit->set_walkdelay_timer, target->id, ddelay);
+	int damage_delay = amotion;
+	int mob_delay;
+
+	if (src->type == BL_MOB && (mob_delay = BL_UCCAST(BL_MOB, src)->status.ddelay) > 0)
+		damage_delay = skill_id == 0 ? mob_delay : 0; // Skills have 0 delay?
+
+	timer->add(timer->gettick() + damage_delay, battle->delay_damage_sub, 0, (intptr_t)dat);
+#else
+	timer->add(tick + amotion, battle->delay_damage_sub, 0, (intptr_t)dat);
 #endif
-	timer->add(tick+amotion, battle->delay_damage_sub, 0, (intptr_t)dat);
 
 	return 0;
 }

--- a/src/map/mob.c
+++ b/src/map/mob.c
@@ -5241,6 +5241,13 @@ static int mob_read_db_sub(struct config_setting_t *mobt, int n, const char *sou
 			md.status.dmotion = i32;
 	}
 
+#ifdef WALKDELAY_SYNC
+	if (map->setting_lookup_const(mobt, "DamageDelay", &i32) && i32 >= 0)
+		md.status.ddelay = cap_value(i32, 0, 10000);
+	else
+		md.status.ddelay = 0;
+#endif
+
 	// MVP EXP Bonus: MEXP
 	if (map->setting_lookup_const(mobt, "MvpExp", &i32) && i32 >= 0) {
 		// Some new MVP's MEXP multiple by high exp-rate cause overflow. [LuzZza]

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -409,10 +409,8 @@ static int status_damage(struct block_list *src, struct block_list *target, int6
 
 	if (st->hp || (flag&8)) {
 		//Still lives or has been dead before this damage.
-#ifndef WALKDELAY_SYNC
 		if (walkdelay)
 			unit->set_walkdelay(target, timer->gettick(), walkdelay, 0);
-#endif
 		return (int)(hp+sp);
 	}
 

--- a/src/map/status.h
+++ b/src/map/status.h
@@ -1118,6 +1118,9 @@ struct status_data {
 		matk_min, matk_max,
 		speed,
 		amotion, adelay, dmotion,
+#ifdef WALKDELAY_SYNC
+		ddelay,
+#endif
 		mode;
 	int32 hit, flee, cri, flee2,
 		def2, mdef2,


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" and
     enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude

<!-- Thank you for working on improving Hercules! -->
<!-- Please complete these steps and check the following boxes by putting an `x`
     inside the [brackets] before filing your Pull Request. -->

- [x] I have followed [proper Hercules code styling][code].
- [x] I have read and understood the [contribution guidelines][cont] before making this PR.
- [x] I am aware that this PR may be closed if the above-mentioned criteria are not fulfilled.

### Changes Proposed
Added DamageDelay setting. This setting allows a more precise walk delay interaction between server and client.
Only usable with macro option WALKDELAY_SYNC
<!-- Describe the changes that this pull request makes. -->

**Issues addressed:** <!-- Write here the issue number, if any. -->
None

<!-- You can safely ignore the links below:  -->

[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style
