### PR TITLE
Fixed Rogue's plagiarize losing skills when copying skills from its own skill tree

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,6 +7,7 @@
 .ycm_extra_conf.py*
 Thumbs.db
 .vscode
+enc_temp_folder
 
 # /
 /*.exe

--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -5729,8 +5729,15 @@ static void clif_skillup(struct map_session_data *sd, uint16 skill_id, int skill
 	WFIFOW(fd, 0) = 0x10e;
 	WFIFOW(fd, 2) = skill_id;
 	WFIFOW(fd, 4) = skill_lv;
-	WFIFOW(fd, 6) = skill->get_sp(skill_id, skill_lv);
-	WFIFOW(fd, 8) = (flag)?skill->get_range2(&sd->bl, skill_id, skill_lv) : skill->get_range(skill_id, skill_lv);
+
+	if (skill_lv > 0) {
+		WFIFOW(fd, 6) = skill->get_sp(skill_id, skill_lv);
+		WFIFOW(fd, 8) = (flag)?skill->get_range2(&sd->bl, skill_id, skill_lv) : skill->get_range(skill_id, skill_lv);
+	} else {
+		WFIFOW(fd, 6) = 0;
+		WFIFOW(fd, 8) = 0;
+	}
+
 	if( flag )
 		WFIFOB(fd,10) = (skill_lv < skill->tree_get_max(skill_id, sd->status.class)) ? 1 : 0;
 	else

--- a/src/map/pc.h
+++ b/src/map/pc.h
@@ -1074,6 +1074,7 @@ END_ZEROED_BLOCK; /* End */
 	int (*maxparameterincrease) (struct map_session_data* sd, int type);
 	bool (*statusup) (struct map_session_data *sd, int type, int increase);
 	int (*statusup2) (struct map_session_data *sd,int type,int val);
+	bool (*isownskill) (struct map_session_data* sd, uint16 skill_id);
 	int (*skillup) (struct map_session_data *sd,uint16 skill_id);
 	int (*allskillup) (struct map_session_data *sd);
 	int (*resetlvl) (struct map_session_data *sd,int type);

--- a/src/map/status.c
+++ b/src/map/status.c
@@ -2395,8 +2395,12 @@ static int status_calc_pc_(struct map_session_data *sd, enum e_status_calc_opt o
 		// Client doesn't delete unavailable skills even if we refresh
 		// the skill tree, individually delete them.
 		for (i = 0; i < MAX_SKILL_DB; i++) {
-			if (b_skill[i].id != 0 && sd->status.skill[i].id == 0)
+			if (b_skill[i].id != 0 && sd->status.skill[i].id == 0) {
 				clif->deleteskill(sd, b_skill[i].id, true);
+				// Skills that belong to the skill tree need to be "downgraded"
+				if (pc->isownskill(sd, b_skill[i].id))
+					clif->skillup(sd, b_skill[i].id, 0, 1);
+			}
 		}
 #endif
 		clif->skillinfoblock(sd);

--- a/src/plugins/HPMHooking/HPMHooking.Defs.inc
+++ b/src/plugins/HPMHooking/HPMHooking.Defs.inc
@@ -7198,6 +7198,8 @@ typedef bool (*HPMHOOK_pre_pc_statusup) (struct map_session_data **sd, int *type
 typedef bool (*HPMHOOK_post_pc_statusup) (bool retVal___, struct map_session_data *sd, int type, int increase);
 typedef int (*HPMHOOK_pre_pc_statusup2) (struct map_session_data **sd, int *type, int *val);
 typedef int (*HPMHOOK_post_pc_statusup2) (int retVal___, struct map_session_data *sd, int type, int val);
+typedef bool (*HPMHOOK_pre_pc_isownskill) (struct map_session_data **sd, uint16 *skill_id);
+typedef bool (*HPMHOOK_post_pc_isownskill) (bool retVal___, struct map_session_data *sd, uint16 skill_id);
 typedef int (*HPMHOOK_pre_pc_skillup) (struct map_session_data **sd, uint16 *skill_id);
 typedef int (*HPMHOOK_post_pc_skillup) (int retVal___, struct map_session_data *sd, uint16 skill_id);
 typedef int (*HPMHOOK_pre_pc_allskillup) (struct map_session_data **sd);

--- a/src/plugins/HPMHooking/HPMHooking_map.HPMHooksCore.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.HPMHooksCore.inc
@@ -5176,6 +5176,8 @@ struct {
 	struct HPMHookPoint *HP_pc_statusup_post;
 	struct HPMHookPoint *HP_pc_statusup2_pre;
 	struct HPMHookPoint *HP_pc_statusup2_post;
+	struct HPMHookPoint *HP_pc_isownskill_pre;
+	struct HPMHookPoint *HP_pc_isownskill_post;
 	struct HPMHookPoint *HP_pc_skillup_pre;
 	struct HPMHookPoint *HP_pc_skillup_post;
 	struct HPMHookPoint *HP_pc_allskillup_pre;
@@ -12733,6 +12735,8 @@ struct {
 	int HP_pc_statusup_post;
 	int HP_pc_statusup2_pre;
 	int HP_pc_statusup2_post;
+	int HP_pc_isownskill_pre;
+	int HP_pc_isownskill_post;
 	int HP_pc_skillup_pre;
 	int HP_pc_skillup_post;
 	int HP_pc_allskillup_pre;

--- a/src/plugins/HPMHooking/HPMHooking_map.HookingPoints.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.HookingPoints.inc
@@ -2653,6 +2653,7 @@ struct HookingPointData HookingPoints[] = {
 	{ HP_POP(pc->maxparameterincrease, HP_pc_maxparameterincrease) },
 	{ HP_POP(pc->statusup, HP_pc_statusup) },
 	{ HP_POP(pc->statusup2, HP_pc_statusup2) },
+	{ HP_POP(pc->isownskill, HP_pc_isownskill) },
 	{ HP_POP(pc->skillup, HP_pc_skillup) },
 	{ HP_POP(pc->allskillup, HP_pc_allskillup) },
 	{ HP_POP(pc->resetlvl, HP_pc_resetlvl) },

--- a/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
@@ -68816,6 +68816,33 @@ int HP_pc_statusup2(struct map_session_data *sd, int type, int val) {
 	}
 	return retVal___;
 }
+bool HP_pc_isownskill(struct map_session_data *sd, uint16 skill_id) {
+	int hIndex = 0;
+	bool retVal___ = false;
+	if (HPMHooks.count.HP_pc_isownskill_pre > 0) {
+		bool (*preHookFunc) (struct map_session_data **sd, uint16 *skill_id);
+		*HPMforce_return = false;
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_pc_isownskill_pre; hIndex++) {
+			preHookFunc = HPMHooks.list.HP_pc_isownskill_pre[hIndex].func;
+			retVal___ = preHookFunc(&sd, &skill_id);
+		}
+		if (*HPMforce_return) {
+			*HPMforce_return = false;
+			return retVal___;
+		}
+	}
+	{
+		retVal___ = HPMHooks.source.pc.isownskill(sd, skill_id);
+	}
+	if (HPMHooks.count.HP_pc_isownskill_post > 0) {
+		bool (*postHookFunc) (bool retVal___, struct map_session_data *sd, uint16 skill_id);
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_pc_isownskill_post; hIndex++) {
+			postHookFunc = HPMHooks.list.HP_pc_isownskill_post[hIndex].func;
+			retVal___ = postHookFunc(retVal___, sd, skill_id);
+		}
+	}
+	return retVal___;
+}
 int HP_pc_skillup(struct map_session_data *sd, uint16 skill_id) {
 	int hIndex = 0;
 	int retVal___ = 0;


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" if necessary
     and enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude
<!-- Thank you for working on improving Heracles! -->
By submitting this Pull Request I confirm I have followed [proper Hercules code styling][code] and that I have read and understood the [contribution guidelines][cont].

### Changes Proposed
Fixed Rogue's plagiarize losing skills when copying skills from its own skill tree.
In addition, this fixes other instances in recent clients where equipment or altered status grant skills that already were in the character skilltree and weren't removed from the client side skill tree once the equipment was unequipped or the status finished.

**Issues addressed:** <!-- Write here the issue number, if any. -->
Hercules issue https://github.com/HerculesWS/Hercules/issues/3289

<!-- You can safely ignore the links below:  -->
[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style