### PR TITLE
Fixed WALKDELAY_SYNC not working correctly with damage delay

### DIFF
--- a/src/map/status.c
+++ b/src/map/status.c
@@ -409,8 +409,10 @@ static int status_damage(struct block_list *src, struct block_list *target, int6
 
 	if (st->hp || (flag&8)) {
 		//Still lives or has been dead before this damage.
-		if (walkdelay)
-			unit->set_walkdelay(target, timer->gettick(), walkdelay, 0);
+#ifndef WALKDELAY_SYNC
+			if (walkdelay)
+				unit->set_walkdelay(target, timer->gettick(), walkdelay, 0);
+#endif
 		return (int)(hp+sp);
 	}
 

--- a/src/map/unit.c
+++ b/src/map/unit.c
@@ -1345,6 +1345,29 @@ static int unit_resume_running(int tid, int64 tick, int id, intptr_t data)
 
 }
 
+/**
+ * Timer function for applying walk delay
+ * 
+ * @param tid Timer id
+ * @param tick Timer tick
+ * @param id Target id
+ * @param data DWord of delay + type
+ */
+static int unit_set_walkdelay_timer(int tid, int64 tick, int id, intptr_t data)
+{
+	struct block_list *target = map->id2bl(id);
+
+	if (target == NULL)
+		return 0;
+
+	int delay = (int)GetWord((uint32)data, 0);
+	int type = (int)GetWord((uint32)data, 1);
+
+	unit->set_walkdelay(target, tick, delay, type);
+
+	return 0;
+}
+
 /*==========================================
  * Applies walk delay to character, considering that
  * if type is 0, this is a damage induced delay: if previous delay is active, do not change it.
@@ -3236,6 +3259,7 @@ void unit_defaults(void)
 	unit->is_walking = unit_is_walking;
 	unit->can_move = unit_can_move;
 	unit->resume_running = unit_resume_running;
+	unit->set_walkdelay_timer = unit_set_walkdelay_timer;
 	unit->set_walkdelay = unit_set_walkdelay;
 	unit->skilluse_id2 = unit_skilluse_id2;
 	unit->skilluse_pos = unit_skilluse_pos;

--- a/src/map/unit.h
+++ b/src/map/unit.h
@@ -129,6 +129,7 @@ struct unit_interface {
 	int (*is_walking) (struct block_list *bl);
 	int (*can_move) (struct block_list *bl);
 	int (*resume_running) (int tid, int64 tick, int id, intptr_t data);
+	int (*set_walkdelay_timer) (int tid, int64 tick, int id, intptr_t data);
 	int (*set_walkdelay) (struct block_list *bl, int64 tick, int delay, int type);
 	int (*skilluse_id2) (struct block_list *src, int target_id, uint16 skill_id, uint16 skill_lv, int casttime, int castcancel);
 	int (*skilluse_pos) (struct block_list *src, short skill_x, short skill_y, uint16 skill_id, uint16 skill_lv);

--- a/src/plugins/HPMHooking/HPMHooking.Defs.inc
+++ b/src/plugins/HPMHooking/HPMHooking.Defs.inc
@@ -9626,6 +9626,8 @@ typedef int (*HPMHOOK_pre_unit_can_move) (struct block_list **bl);
 typedef int (*HPMHOOK_post_unit_can_move) (int retVal___, struct block_list *bl);
 typedef int (*HPMHOOK_pre_unit_resume_running) (int *tid, int64 *tick, int *id, intptr_t *data);
 typedef int (*HPMHOOK_post_unit_resume_running) (int retVal___, int tid, int64 tick, int id, intptr_t data);
+typedef int (*HPMHOOK_pre_unit_set_walkdelay_timer) (int *tid, int64 *tick, int *id, intptr_t *data);
+typedef int (*HPMHOOK_post_unit_set_walkdelay_timer) (int retVal___, int tid, int64 tick, int id, intptr_t data);
 typedef int (*HPMHOOK_pre_unit_set_walkdelay) (struct block_list **bl, int64 *tick, int *delay, int *type);
 typedef int (*HPMHOOK_post_unit_set_walkdelay) (int retVal___, struct block_list *bl, int64 tick, int delay, int type);
 typedef int (*HPMHOOK_pre_unit_skilluse_id2) (struct block_list **src, int *target_id, uint16 *skill_id, uint16 *skill_lv, int *casttime, int *castcancel);

--- a/src/plugins/HPMHooking/HPMHooking_map.HPMHooksCore.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.HPMHooksCore.inc
@@ -7522,6 +7522,8 @@ struct {
 	struct HPMHookPoint *HP_unit_can_move_post;
 	struct HPMHookPoint *HP_unit_resume_running_pre;
 	struct HPMHookPoint *HP_unit_resume_running_post;
+	struct HPMHookPoint *HP_unit_set_walkdelay_timer_pre;
+	struct HPMHookPoint *HP_unit_set_walkdelay_timer_post;
 	struct HPMHookPoint *HP_unit_set_walkdelay_pre;
 	struct HPMHookPoint *HP_unit_set_walkdelay_post;
 	struct HPMHookPoint *HP_unit_skilluse_id2_pre;
@@ -15081,6 +15083,8 @@ struct {
 	int HP_unit_can_move_post;
 	int HP_unit_resume_running_pre;
 	int HP_unit_resume_running_post;
+	int HP_unit_set_walkdelay_timer_pre;
+	int HP_unit_set_walkdelay_timer_post;
 	int HP_unit_set_walkdelay_pre;
 	int HP_unit_set_walkdelay_post;
 	int HP_unit_skilluse_id2_pre;

--- a/src/plugins/HPMHooking/HPMHooking_map.HookingPoints.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.HookingPoints.inc
@@ -3850,6 +3850,7 @@ struct HookingPointData HookingPoints[] = {
 	{ HP_POP(unit->is_walking, HP_unit_is_walking) },
 	{ HP_POP(unit->can_move, HP_unit_can_move) },
 	{ HP_POP(unit->resume_running, HP_unit_resume_running) },
+	{ HP_POP(unit->set_walkdelay_timer, HP_unit_set_walkdelay_timer) },
 	{ HP_POP(unit->set_walkdelay, HP_unit_set_walkdelay) },
 	{ HP_POP(unit->skilluse_id2, HP_unit_skilluse_id2) },
 	{ HP_POP(unit->skilluse_pos, HP_unit_skilluse_pos) },

--- a/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
+++ b/src/plugins/HPMHooking/HPMHooking_map.Hooks.inc
@@ -100572,6 +100572,33 @@ int HP_unit_resume_running(int tid, int64 tick, int id, intptr_t data) {
 	}
 	return retVal___;
 }
+int HP_unit_set_walkdelay_timer(int tid, int64 tick, int id, intptr_t data) {
+	int hIndex = 0;
+	int retVal___ = 0;
+	if (HPMHooks.count.HP_unit_set_walkdelay_timer_pre > 0) {
+		int (*preHookFunc) (int *tid, int64 *tick, int *id, intptr_t *data);
+		*HPMforce_return = false;
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_unit_set_walkdelay_timer_pre; hIndex++) {
+			preHookFunc = HPMHooks.list.HP_unit_set_walkdelay_timer_pre[hIndex].func;
+			retVal___ = preHookFunc(&tid, &tick, &id, &data);
+		}
+		if (*HPMforce_return) {
+			*HPMforce_return = false;
+			return retVal___;
+		}
+	}
+	{
+		retVal___ = HPMHooks.source.unit.set_walkdelay_timer(tid, tick, id, data);
+	}
+	if (HPMHooks.count.HP_unit_set_walkdelay_timer_post > 0) {
+		int (*postHookFunc) (int retVal___, int tid, int64 tick, int id, intptr_t data);
+		for (hIndex = 0; hIndex < HPMHooks.count.HP_unit_set_walkdelay_timer_post; hIndex++) {
+			postHookFunc = HPMHooks.list.HP_unit_set_walkdelay_timer_post[hIndex].func;
+			retVal___ = postHookFunc(retVal___, tid, tick, id, data);
+		}
+	}
+	return retVal___;
+}
 int HP_unit_set_walkdelay(struct block_list *bl, int64 tick, int delay, int type) {
 	int hIndex = 0;
 	int retVal___ = 0;


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" if necessary
     and enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude
<!-- Thank you for working on improving Heracles! -->
By submitting this Pull Request I confirm I have followed [proper Hercules code styling][code] and that I have read and understood the [contribution guidelines][cont].

### Changes Proposed
<!-- Describe the changes that this pull request makes. -->
Fix interaction between walkdelay and damage delay (and also delay_battle_damage configuration option).


**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->
[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style