### PR TITLE
Fixed WALKDELAY_SYNC not applying walkdelay in some circumstances

### DIFF
--- a/src/map/status.c
+++ b/src/map/status.c
@@ -409,10 +409,8 @@ static int status_damage(struct block_list *src, struct block_list *target, int6
 
 	if (st->hp || (flag&8)) {
 		//Still lives or has been dead before this damage.
-#ifndef WALKDELAY_SYNC
 		if (walkdelay)
 			unit->set_walkdelay(target, timer->gettick(), walkdelay, 0);
-#endif
 		return (int)(hp+sp);
 	}
 


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" if necessary
     and enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude
<!-- Thank you for working on improving Heracles! -->
By submitting this Pull Request I confirm I have followed [proper Hercules code styling][code] and that I have read and understood the [contribution guidelines][cont].

### Changes Proposed
<!-- Describe the changes that this pull request makes. -->
Fixed flag WALKDELAY_SYNC in cases other skills/mechanics were applying damage and walkdelay by other means.

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->
[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style