### PR TITLE
Fixed skills from equipment not being properly removed in modern clients

### DIFF
--- a/src/map/status.c
+++ b/src/map/status.c
@@ -2378,11 +2378,13 @@ static int status_calc_pc_(struct map_session_data *sd, enum e_status_calc_opt o
 
 	if (memcmp(b_skill, sd->status.skill, sizeof(sd->status.skill))) {
 #if PACKETVER_MAIN_NUM >= 20190807 || PACKETVER_RE_NUM >= 20190807 || PACKETVER_ZERO_NUM >= 20190918
-		// Client doesn't delete unavailable skills even if we refresh
-		// the skill tree, individually delete them.
+		// Client doesn't delete unavailable skills even if we refresh the skill tree, individually delete/update them.
 		for (i = 0; i < MAX_SKILL_DB; i++) {
 			if (b_skill[i].id != 0 && sd->status.skill[i].id == 0) {
-				clif->deleteskill(sd, b_skill[i].id, true);
+				if (pc->is_own_skill(sd, b_skill[i].id))
+					clif->skillinfo(sd, b_skill[i].id, 0);
+				else
+					clif->deleteskill(sd, b_skill[i].id, true);
 			}
 		}
 #endif


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" if necessary
     and enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude
<!-- Thank you for working on improving Heracles! -->
By submitting this Pull Request I confirm I have followed [proper Hercules code styling][code] and that I have read and understood the [contribution guidelines][cont].

### Changes Proposed
<!-- Describe the changes that this pull request makes. -->
Fixes skills granted by equipment not resetting their level when the equipment is removed, if the skill belongs to the character's skill tree.

**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->
[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style