### PR TITLE
Fixed single cell movement when dealing with two consecutive units

### DIFF
--- a/src/map/clif.c
+++ b/src/map/clif.c
@@ -11838,9 +11838,10 @@ static void clif_parse_WalkToXY(int fd, struct map_session_data *sd)
 
 	// Do not allow one cell move commands if the target cell is not free
 	if (battle_config.official_cell_stack_limit > 0
-		&& (sd->bl.x != x || sd->bl.y != y) // Allow current cell
-		&& check_distance_blxy(&sd->bl, x, y, 1)
-		&& map->count_oncell(sd->bl.m, x, y, BL_CHAR | BL_NPC, 0x1 | 0x2) >= battle_config.official_cell_stack_limit)
+		&& sd->bl.x == x + 1
+		&& sd->bl.y == y
+		&& map->count_oncell(sd->bl.m, x, y, BL_CHAR | BL_NPC, 0x1 | 0x2) >= battle_config.official_cell_stack_limit
+		&& !map->closest_freecell(sd->bl.m, &sd->bl, &x, &y, BL_CHAR | BL_NPC, 0))
 		return;
 
 	pc->delinvincibletimer(sd);


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" if necessary
     and enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude
<!-- Thank you for working on improving Heracles! -->
By submitting this Pull Request I confirm I have followed [proper Hercules code styling][code] and that I have read and understood the [contribution guidelines][cont].

### Changes Proposed
<!-- Describe the changes that this pull request makes. -->
Fixed a regression introduced in https://github.com/HerculesWS/Hercules/pull/3259 where single-cell movements would be canceled when interacting with two consecutive objects. The current solution applies the logic only when walking east. Furthermore, an additional fix has been implemented so that the server attempts to locate an adjacent cell to circumvent the issue before canceling the move request.


**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->
[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style