### PR TITLE
Always use type 0 for damage-induced walk delay

### DIFF
--- a/src/map/battle.c
+++ b/src/map/battle.c
@@ -367,7 +367,7 @@ static int battle_delay_damage(int64 tick, int amotion, struct block_list *src, 
 		walkdelay_latency = skill_id == 0 ? mob_delay : 0; // Skills have 0 delay?
 
 	if (damage > 0)
-		timer->add(timer->gettick() + walkdelay_latency, unit->set_walkdelay_timer, target->id, MakeDWord(ddelay, skill_id != 0));
+		timer->add(timer->gettick() + walkdelay_latency, unit->set_walkdelay_timer, target->id, ddelay);
 #endif
 
 	timer->add(tick + amotion, battle->delay_damage_sub, 0, (intptr_t)dat);

--- a/src/map/unit.c
+++ b/src/map/unit.c
@@ -1360,10 +1360,7 @@ static int unit_set_walkdelay_timer(int tid, int64 tick, int id, intptr_t data)
 	if (target == NULL)
 		return 0;
 
-	int delay = (int)GetWord((uint32)data, 0);
-	int type = (int)GetWord((uint32)data, 1);
-
-	unit->set_walkdelay(target, tick, delay, type);
+	unit->set_walkdelay(target, tick, (int32)data, 0);
 
 	return 0;
 }


### PR DESCRIPTION
<!-- Before you continue, please change "base: stable" to "base: master" if necessary
     and enable the setting "[√] Allow edits from maintainers." when creating your
     pull request if you have not already enabled it. -->

<!-- Note: Lines with this <!-- syntax are comments and will not be visible in
     your pull request. You can safely ignore or remove them. -->

### Pull Request Prelude
<!-- Thank you for working on improving Heracles! -->
By submitting this Pull Request I confirm I have followed [proper Hercules code styling][code] and that I have read and understood the [contribution guidelines][cont].

### Changes Proposed
<!-- Describe the changes that this pull request makes. -->
Always use type 0 when setting walkdelay with walkdelay_sync. Fixes monsters reproducing the walking animation when trapped.
Thanks to pondwater (at discord) for noticing the issue.


**Issues addressed:** <!-- Write here the issue number, if any. -->


<!-- You can safely ignore the links below:  -->
[cont]: https://github.com/HerculesWS/Hercules/blob/master/CONTRIBUTING.md
[code]: https://github.com/HerculesWS/Hercules/wiki/Coding-Style